### PR TITLE
Wait before changing boot order

### DIFF
--- a/ansible-ipi-install/roles/shared-labs-prep/tasks/main.yml
+++ b/ansible-ipi-install/roles/shared-labs-prep/tasks/main.yml
@@ -146,6 +146,20 @@
   tags:
     - clearjobs
 
+- name: Wait for iDrac to be responsive (check via --check-boot)
+  shell:
+    chdir: "{{ badfish_tempdir.path }}/src/badfish"
+    cmd: |
+      source {{ badfish_venv }}/bin/activate
+      {{ badfish_cmd }}{{ item }} --check-boot
+  with_items:
+    - "{{ master_fqdns }}"
+    - "{{ worker_fqdns }}"
+  register: wait_for_idrac
+  until: wait_for_idrac is succeeded
+  retries: 20
+  delay: 30
+
 - name: Set nodes to director boot order
   shell:
     chdir: "{{ badfish_tempdir.path }}/src/badfish"


### PR DESCRIPTION
Changing boot order is failing in some cases as they idrac
goes unresponsive after the force clear of the queue

Fixes: #19

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
