### PR TITLE
Allow playbook execution from remote host

### DIFF
--- a/ansible-ipi-install/group_vars/all.yml
+++ b/ansible-ipi-install/group_vars/all.yml
@@ -1,7 +1,3 @@
-# This is the location on the jumphost (ansible controller) where the list 
-# of hosts your lab allocation will be downloaded to in json format. 
-# Leave default, for most cases
-ocpinv_file: "{{ playbook_dir }}/ocpinv.json"
 # Your allocation name/number in the shared labs
 cloud_name: cloud00
 # Lab name, typically can be alias or scale

--- a/ansible-ipi-install/inventory/jetski/hosts
+++ b/ansible-ipi-install/inventory/jetski/hosts
@@ -154,3 +154,7 @@ network_type="OVNKubernetes"
 #   content sources for the local registry. The contents of this file
 #   will be appended to the install-config.yml file.
 # disconnected_registry_mirrors_file=/path/to/install-config-appends.json
+
+[orchestration]
+localhost ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"
+

--- a/ansible-ipi-install/playbook-jetski.yml
+++ b/ansible-ipi-install/playbook-jetski.yml
@@ -1,6 +1,6 @@
 ---
 - name: IPI on Baremetal Installation Playbook -- Red Hat Shared Labs JetSki Edition
-  hosts: localhost
+  hosts: orchestration
   roles:
     - { role: bootstrap }
 
@@ -8,7 +8,7 @@
   roles:
     - { role: prepare-kni, ssh_path: /root/.ssh}
 
-- hosts: localhost
+- hosts: orchestration
   roles:
     - { role: add-provisioner }
 

--- a/ansible-ipi-install/roles/bootstrap/tasks/01_install_packages.yml
+++ b/ansible-ipi-install/roles/bootstrap/tasks/01_install_packages.yml
@@ -1,5 +1,5 @@
 - name: install packages
-  yum:
+  package:
     name: [ python3-dns, python3-netaddr]
   become: true
 

--- a/ansible-ipi-install/roles/bootstrap/tasks/10_load_inv.yml
+++ b/ansible-ipi-install/roles/bootstrap/tasks/10_load_inv.yml
@@ -1,6 +1,6 @@
 - name: set fact for inv file
   set_fact:
-    ocpinv_file: "{{ ocpinv_file|default('{{ playbook_dir }}/ocpinv.json', true) }}"
+    ocpinv_file: "{{ (inventory_hostname == 'localhost') |  ternary(playbook_dir +  '/ocpinv.json', ansible_user_dir + '/ocpinv.json') }}"
 
 - name: check ocpinv file available
   stat:
@@ -24,9 +24,14 @@
   when: not st.stat.exists | bool and lab_name == "scale"
 
 - name: read inv env file
+  slurp:
+    src: "{{ ocpinv_file }}"
+  register: invfile
+
+- name: set inventory facts
   set_fact:
-    ocpinv_content: "{{ lookup('file', '{{ ocpinv_file }}') | from_json }}"
-    ocp_node_inv_path: "{{ playbook_dir }}/ocpnodeinv.json"
+    ocpinv_content: "{{ invfile['content'] | b64decode | from_json }}"
+    ocp_node_inv_path: "{{ ansible_user_dir }}/ocpnodeinv.json"
 
 - name: set provisioning host and ocp cluster info
   block:

--- a/ansible-ipi-install/roles/network-discovery/tasks/main.yml
+++ b/ansible-ipi-install/roles/network-discovery/tasks/main.yml
@@ -10,11 +10,11 @@
 
 - name: Get the bm mac address on provisioner node
   set_fact:
-    bm_mac: "{{ hostvars['localhost']['ocpinv_content']['nodes'][0].mac[2] | lower }}"
+    bm_mac: "{{ hostvars[groups['orchestration'][0]]['ocpinv_content']['nodes'][0].mac[2] | lower }}"
 
 - name: Get the bm provisioning address on provisioner node
   set_fact:
-    prov_mac: "{{ hostvars['localhost']['ocpinv_content']['nodes'][0].mac[1] | lower }}"
+    prov_mac: "{{ hostvars[groups['orchestration'][0]]['ocpinv_content']['nodes'][0].mac[1] | lower }}"
 
 - name: Set the lab public nic
   set_fact: 

--- a/ansible-ipi-install/roles/set-deployment-facts/tasks/main.yml
+++ b/ansible-ipi-install/roles/set-deployment-facts/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
-# Below task is to make sure all the vars as avaialble as hostvars on provisioner and not only localhost (for good measure)
+# Below task is to make sure all the vars as avaialble as hostvars on provisioner and not only localhost
 - name: set facts needed for OCP deployment on the provisioning host
   set_fact:
-     "{{ item }}": "{{ hostvars['localhost'][item] }}"
+     "{{ item }}": "{{ hostvars[groups['orchestration'][0]][item] }}"
   with_items:
     - master_fqdns
     - worker_fqdns


### PR DESCRIPTION
Currently the playbook-jetski.yml and the roles are written such
that the playbook only works when run from localhost.

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>

# Description

## Motivation behind the change
The main motivation behind this change is to enable JetSki to be run from a remote host instead of implicit localhost, for the purposes of CI/Jenkins environments. Currently certain plays in playbook-jetski.yml run on implicit localhost and all the facts set on the implicit localhost are conveniently accessed using hostvars['localhost'] in several roles. 

When the playbook/roles were written and the way it was written did not necessitate the need to actually be able to set a different remote other than localhost (for running the bootstrap and add-provisioner roles) as for the most part the `provisioner` host is already like a remote host and that's where most of the install is orchestrated from, except that we run the `bootstrap` and `add-provisioner` roles on implicit localhost to set facts needed for the playbook execution. See snippet below for example,
```- name: IPI on Baremetal Installation Playbook -- Red Hat Shared Labs JetSki Edition
  hosts: localhost
  roles:
    - { role: bootstrap }
```
localhost referenced in the above play is the implicit localhost (the ansible controller host)
Whenever we make a jenkins job, it is ideal to consume variables/parameters needed for the job to run as jenkins parameters which get translated into environment variables on the jenkins slave/executor. That we can consume those vars in our existing schema of group_vars/all.yml by using lookups as follows, https://github.com/redhat-performance/JetSki-Configs/blob/master/ci/group_vars/all.yml. Do note that lookups execute on the ansible controller and not the remote host. 

We currently assume the host from which JetSKi satisfies following requirements:

1. Fedora 30+
2. Python 3
3. Sudo access for user (jenkins user)
4. Installation of packages such as python3-dns, python3-netaddr and podman
5. Ability to run podman container (for hammercli as well as badfish)

Since there is no guarantee that all these requirements can be met by the jenkins slave, it would be ideal to execute this playbook from an orchestration/jumphost (So job runs on jenkins slave and the playbook is kicked off from the jenkins slave, but to be executed against a remote orchestration host and the provisioner host in the plays and not on implicit localhost). 

 I tried something like this in the jenkins job,
 
```ssh -T -i ${PRIVATE_KEY} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${ORCHESTRATION_USER} <<EOSSH
git clone https://github.com/redhat-performance/JetSki.git
git clone https://${SSHKEY_TOKEN}@github.com/redhat-performance/JetSki-Configs
cp JetSki-Configs/ci/group_vars/all.yml JetSki/ansible-ipi-install/group_vars
pushd JetSki/ansible-ipi-install
ansible-playbook -i inventory/jetski/hosts playbook-jetski.yml
EOSSH
```

This did not work with the current way the playbook are written and the idea of consuming group_vars/all.yml using environmental lookups. The problem however is the environment variables on the jenkins host (which were supposed to be used by lookups in the group_vars/all.yml for setting variables needed for playbook run)  are now not accessible on the orchestration host ${ORCHESTRATION_HOST}  so all our lookups in group_vars/all.yml will fail.  We can add the ability to pass environment variables over SSH using the AcceptEnv  and SendEnv options in the sshd config (among other ways) but it is not ideal to expect this level of access to our jenkins slave or orchestration user. Since the JetSki playbook auto-generates inventory and adds variables needed as facts/hostvars and we access hostvars from implicit `localhost` as in https://github.com/redhat-performance/JetSki/blob/master/ansible-ipi-install/roles/network-discovery/tasks/main.yml#L13 (among other places), we need a rework of how the playbook is run and it's not straightforward

## Explanation of changes

The following files were changed and here's a brief summary of the changes
1. `playbook-jetski.yml`: Certain plays of the playbook are now set to run from the orchestration user (group) instead of using the implicit localhost
2. `inventory/jetski/hosts`: We now introduce and orchestration group and add the localhost by default, so there is no change in the way people currently use the playbook (running it from localhost like the laptop should work OOTB). We set the `ansible_connection=local` to remove the need for the user to add ssh keys as ansible tries to ssh to localhost otherwise and we also need to add the `ansible_python_interpreter={{ ansible_playbook_python }}` because of the various nuances in how ansible deals with python2/3 interpreters. Without this, on my Fedora 30 laptop, ansible always tried to install python2-dnf (which is not available) when running the dnf/yum module (in the bootstrap/01_install_packages.yml task file). It used to work earlier without specifying the python interpreter because at that point the implicit localhost was being used instead of localhost from an explicitly defined inventory file. Please refer to https://docs.ansible.com/ansible/latest/inventory/implicit_localhost.html and https://github.com/ansible/ansible/issues/54855 for more details. 

If a user wants to execute JetSki from a remote host, they would add the remote host's details under the [orchestration] group as in
```
[orchestration]
abc.example.com ansible_ssh_user=root
```
after copying the keys to the orchestration host
3. `group_vars/all.yml`:  The default value for `ocpinv_file` is now removed and is dynamically set within `roles/bootstrap/tasks/10_load_inv.yml` since the `playbook_dir` ansible var will be set to the directory from which the playbook is executing and this directory will not exist on the remote host when ansible tries to download the inventory file to that location. So, the idea is to use `playbook_dir` when running on `localhost` and `ansible_user_dir` when using a remote host for orchestration.
4. `roles/bootstrap/tasks/01_install_packages.yml`: Switch yum module to package, mostly a cosmetic change not really required for this feature to work, but figured it would be nice to move on to the generic package module which works across CentOS 7/8.
5. `roles/bootstrap/tasks/10_load_inv.yml`:  Dynamically set the location of `ocpinv_file` depending on whether the playbook is using `localhost` for orchestration or a remote host. Also, changed the file lookup to read the contents of `ocpinv_file` to actually use slurp because the lookup won't work on remote host (if our orchestration host is some abc.example.com and we downloaded the ocpinv_file there, lookup won't work since it is executed on the ansible controller and not the remote orchestration host)
6.`roles/network-discovery/tasks/main.yml `:  Changed the tasks which access things like `"{{ hostvars['localhost'] }}` to `{{  hostvars[groups['orchestration'][0]] }}`. This is because we are no longer registering the facts on the implicit locahost and whether we define `localhost` in our `inventory/jetski/hosts` or some remote `abc.example.com`  `hostvars[groups['orchestration'][0]]` will work as it simply access the hostvars from the first host (0th in a pythonic sense) of the orchestration group. It is important we access the variables this way as simple `hostvars['abc.exaple.com']` won't work within the task since we don't know the inventory name of the orchestration hostand can't hardcode it in the task. (hardcording to implicit localhost worked earlier as the facts were also registered on implicit localhost)
7. `roles/set-deployment-facts/tasks/main.yml`: Change is similar to what was discussed in the previous bullet point.

## User Impact

Currently there will be no impact to users continuing to run JetSki from their laptops/localhost as we set the orchestration host to localhost by default in the inventory file. More advanced users wanting to run JetSki on a remote host can manually tweak the `inventory/jetski/hosts` file to point to a remote host
Since there is no immediate impact on users and this should all be transparent to users using JetSki in the current way of running from localhost, there is no immediate docs change needed.