### PR TITLE
Support download inventory to tempfile

### DIFF
--- a/ansible-ipi-install/roles/bootstrap/tasks/10_load_inv.yml
+++ b/ansible-ipi-install/roles/bootstrap/tasks/10_load_inv.yml
@@ -1,6 +1,14 @@
+- name: Create temporary directory for inventory
+  tempfile:
+    state: directory
+  register: inventory_tempdir
+ 
 - name: set fact for inv file
   set_fact:
-    ocpinv_file: "{{ (inventory_hostname == 'localhost') |  ternary(playbook_dir +  '/ocpinv.json', ansible_user_dir + '/ocpinv.json') }}"
+    "{{ item.name }}": "{{ (inventory_hostname == 'localhost') |  ternary(playbook_dir +  '/' + item.path, inventory_tempdir.path + '/' + item.path) }}"
+  with_items:
+    - { name: ocpinv_file, path: ocpinv.json }
+    - { name: ocp_node_inv_path, path: ocpnodeinv.json }
 
 - name: check ocpinv file available
   stat:
@@ -28,10 +36,9 @@
     src: "{{ ocpinv_file }}"
   register: invfile
 
-- name: set inventory facts
+- name: set inventory fact
   set_fact:
     ocpinv_content: "{{ invfile['content'] | b64decode | from_json }}"
-    ocp_node_inv_path: "{{ ansible_user_dir }}/ocpnodeinv.json"
 
 - name: set provisioning host and ocp cluster info
   block:


### PR DESCRIPTION
This is needed because when running from the same remote [orchestration] host
although we specificy a new cloud to deploy on, since the location being checked on
remote is {{ansible_user_dir}}/ocpinv.json and it already exists from a previous
deployment, it could be used for the current deploy.

This patch defaults to using a temp location if orechestration is being done from a remote
host, and sticks to {{ playbook_dir }}/ocpinv.json when the localhost is the orchestration
host, for user convenience (if they wanted to manually edit the inventory file and have
JetSki consume it on a subsequent run).

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
