### PR TITLE
Auto-approve CSRs

### DIFF
--- a/ansible-ipi-install/approve_csr.bash
+++ b/ansible-ipi-install/approve_csr.bash
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [ $# -ne 1 ]
+then
+        echo "There should be one arg: the number of workers expected."
+        exit 1
+fi
+
+until [ $(oc get nodes | grep "\bReady\s*worker" | wc -l) == $1 ]
+do
+        oc get csr -ojson | jq -r '.items[] | select(.status == {} ) | .metadata.name' | xargs oc adm certificate approve
+        sleep 5
+done

--- a/ansible-ipi-install/approve_csr.bash
+++ b/ansible-ipi-install/approve_csr.bash
@@ -1,13 +1,23 @@
 #!/bin/bash
 
+# Validate there being one arg
 if [ $# -ne 1 ]
 then
-        echo "There should be one arg: the number of workers expected."
-        exit 1
+    echo "There should be one arg: the number of workers expected."
+    exit 1
 fi
 
+# Loop until the expected number of workers are ready
 until [ $(oc get nodes | grep "\bReady\s*worker" | wc -l) == $1 ]
 do
-        oc get csr -ojson | jq -r '.items[] | select(.status == {} ) | .metadata.name' | xargs oc adm certificate approve
-        sleep 5
+    # Search for CSRs awaiting approval
+    csr_output=$(oc get csr -ojson | jq -r '.items[] | select(.status == {} ) | .metadata.name')
+
+    # Don't run if empty
+    if [ -n "$csr_output" ]
+    then
+        # Approve
+    	echo "$csr_output" | xargs oc adm certificate approve
+    fi
+    sleep 5
 done

--- a/ansible-ipi-install/roles/shared-labs-prep/tasks/main.yml
+++ b/ansible-ipi-install/roles/shared-labs-prep/tasks/main.yml
@@ -248,3 +248,21 @@
       become: yes
       with_items: "{{ disable_nics }}"
   delegate_to: localhost
+
+- name: Copy the approve_csr script from the local machine to the remote server
+  copy:
+    src: ./approve_csr.bash
+    dest: "{{ dir }}"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: 0755
+  become: yes
+  when: worker_count != 0
+
+- name: Approve CSRs
+  poll: 0
+  async: 20000
+  shell: "bash {{ dir }}/approve_csr.bash {{ worker_count }}"
+  register: approve_csr_result
+  when: worker_count != 0
+  ignore_errors: yes


### PR DESCRIPTION
# Description

The change:
- A script is run concurrently to automatically approve CSRs (Certificate Signing Requests).
- It loops until the expected number of workers are "Ready" in `co get nodes`. Once they are "Ready" instead of "NotReady", no more CSR approvals should be needed, it exits, and in my testing it worked.
- The script is copied to the server right before it is run, then it is run using the shell Ansible module. It is not run using the script module because that does not support async tasks.
- It does not run when there are 0 workers.

If you want, I can make the script self-deleting.

Motivation behind this change:
- CSRs are not getting approved in our lab environment for some reason, so this workaround will get the job done without the user needing to manually wait and approve them.

Fixes #24 

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- I ran the playbook with 2 and 0 workers.
- With 0 workers, it properly skipped the task.
- With two workers, it ran and properly exited. All relevant CSRs were approved.
- I also ran it with tasks moved to the installer/tasks/60_deploy_ocp.yml and added a task that checked on the status of the async task, and it worked. It successfully exited, and this was the output:
`"stdout_lines": ["certificatesigningrequest.certificates.k8s.io/csr-85wp9 approved", "certificatesigningrequest.certificates.k8s.io/csr-mfnh8 approved", "certificatesigningrequest.certificates.k8s.io/csr-z9q9p approved", "certificatesigningrequest.certificates.k8s.io/csr-ktkjf approved", "certificatesigningrequest.certificates.k8s.io/csr-pxlkd approved", "certificatesigningrequest.certificates.k8s.io/csr-r95gb approved", "certificatesigningrequest.certificates.k8s.io/csr-p62f4 approved", "certificatesigningrequest.certificates.k8s.io/csr-26d9v approved", "certificatesigningrequest.certificates.k8s.io/csr-6fwpr approved", "certificatesigningrequest.certificates.k8s.io/csr-82vnz approved"]}`

Since it ran early, it probably approved more than just the ones that weren't properly being approved, which explains why there are more than four CSR approvals.

**Test Configuration**:

- Cloud18

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [x] PRs should not be merged unless positively reviewed.
