### PR TITLE
Improve reliability of auto-approve CSRs

### DIFF
--- a/ansible-ipi-install/approve_csr.bash
+++ b/ansible-ipi-install/approve_csr.bash
@@ -7,6 +7,10 @@ then
     exit 1
 fi
 
+echo "Running script to approve CSRs"
+
+export KUBECONFIG=~/clusterconfigs/auth/kubeconfig 
+
 # Loop until the expected number of workers are ready
 until [ $(oc get nodes | grep "\bReady\s*worker" | wc -l) == $1 ]
 do
@@ -21,3 +25,5 @@ do
     fi
     sleep 5
 done
+
+echo "Done approving CSRs due to expected number of Ready workers being found"

--- a/ansible-ipi-install/roles/shared-labs-prep/tasks/main.yml
+++ b/ansible-ipi-install/roles/shared-labs-prep/tasks/main.yml
@@ -257,7 +257,7 @@
 - name: Copy the approve_csr script from the local machine to the remote server
   copy:
     src: ./approve_csr.bash
-    dest: "{{ dir }}"
+    dest: "/home/{{ ansible_user }}/"
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
     mode: 0755
@@ -267,7 +267,11 @@
 - name: Approve CSRs
   poll: 0
   async: 20000
-  shell: "bash {{ dir }}/approve_csr.bash {{ worker_count }}"
+  shell: "bash /home/{{ ansible_user }}/approve_csr.bash {{ worker_count }}"
   register: approve_csr_result
   when: worker_count != 0
-  ignore_errors: yes
+
+- name: Approve CSRs Debug
+  debug:
+    var: approve_csr_result
+  when: worker_count != 0


### PR DESCRIPTION
# Description

This change does a few things:
- Sets an environment variable to try to make sure it can access the kubeconfig
- Puts the script in a new location so that it does not get deleted before it finishes
- Adds a debug message so the user can view the script's result file

Issue: #42 

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

This was tested on Cloud18. JetSki was set with reprovision set to true.
Cloud18 has 6 nodes, so only two worker nodes are being tested with the script.

Since this is not consistently reproduced, it would be best to have several people test this, ideally with more than 2 workers.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
