### PR TITLE
Consolidate bootorder tag

### DIFF
--- a/ansible-ipi-install/roles/shared-labs-prep/tasks/main.yml
+++ b/ansible-ipi-install/roles/shared-labs-prep/tasks/main.yml
@@ -125,6 +125,8 @@
   until: power_on_masters is succeeded
   retries: 3
   delay: 30
+  tags:
+    - bootorder
 
 - name: Power on worker nodes
   ipmi_power:
@@ -137,14 +139,15 @@
   until: power_on_workers is succeeded
   retries: 3
   delay: 30
-
+  tags:
+    - bootorder
 
 - include_tasks: 10_redfish_queue.yml
   with_items:
     - "{{ master_fqdns }}"
     - "{{ worker_fqdns }}"
   tags:  
-    - clearjobs
+    - bootorder
 
 - name: Wait for iDrac to be responsive (check via --check-boot)
   shell:
@@ -159,6 +162,8 @@
   until: wait_for_idrac is succeeded
   retries: 20
   delay: 30
+  tags:
+    - bootorder
 
 - name: Set nodes to director boot order
   shell:
@@ -175,8 +180,6 @@
   delay: 60
   tags:
     - bootorder
-
-#TODO: Add wait for node reboot
 
 - name: Set SELinux permissive
   selinux:


### PR DESCRIPTION
Right now we have two tags clearjobs and bootorder.
This commit does the following:
1. Replace the clearjobs tag with bootorder tag since
   that is also needed only when setting boot order.
2. Add the bootorder tag to power on master/worker nodes
   tasks as they need to be powered on only for badfish
   to work, so if not setting bootorder, we can skip them
3. Adds the bootorder tag to the task that does --check-boot
   since that task is also not needed when not setting boot
   order

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
