### PR TITLE
turn off gpgcheck for rdo packages

### DIFF
--- a/ansible-ipi-install/roles/shared-labs-prep/tasks/main.yml
+++ b/ansible-ipi-install/roles/shared-labs-prep/tasks/main.yml
@@ -10,6 +10,13 @@
     state: latest
   become: yes
 
+- name: Install RDO Packages
+  yum:
+    name: "{{ rdo_packages }}"
+    state: latest
+    disable_gpg_check: yes
+  become: yes
+
 - name: Create temp directory for badfish
   tempfile:
     state: directory

--- a/ansible-ipi-install/roles/shared-labs-prep/vars/main.yml
+++ b/ansible-ipi-install/roles/shared-labs-prep/vars/main.yml
@@ -11,6 +11,7 @@ yum_packages:
   - python3-yaml
   - python3-urllib3
   - python3-requests
+rdo_packages:
   - https://trunk.rdoproject.org/rhel8-master/deps/latest/Packages/python3-crypto-2.6.1-18.el8ost.x86_64.rpm
   - https://trunk.rdoproject.org/rhel8-master/deps/latest/Packages/python3-pyghmi-1.0.22-2.el8ost.noarch.rpm
 badfish_cmd: "./src/badfish/badfish.py -u {{ lab_ipmi_user }} -p {{ lab_ipmi_password }} -i config/idrac_interfaces.yml -H mgmt-"


### PR DESCRIPTION
# Description
RDO doesn't provide gpg checks for their packages, ansible yum module defaults to enabling gpg check. This PR breaks out the RDO packages and turns off gpg check for those packages. 

Fixes # [slack chats](https://coreos.slack.com/archives/CFVMERKJ9/p1601901276101300)

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
