### PR TITLE
Fix issue with using custom inventory

### DIFF
--- a/ansible-ipi-install/roles/bootstrap/tasks/10_load_inv.yml
+++ b/ansible-ipi-install/roles/bootstrap/tasks/10_load_inv.yml
@@ -70,6 +70,17 @@
     content: "{{ ocpinv_content | to_nice_json }}"
   when: not st.stat.exists
 
+- name: Create final inventory used for deployment
+  block:
+    - name: read inv env file
+      slurp:
+        src: "{{ ocpinv_file }}"
+      register: finalinv
+
+    - name: set inventory fact
+      set_fact:
+        ocpinv_content: "{{ finalinv['content'] | b64decode | from_json }}"
+
 - name: set provisioning host and ocp cluster info
   block:
     - name: set provisioner hostname


### PR DESCRIPTION
e541aeda1522bc3ebd7b28a72e327bd1b1c56260 which added the mechanism
to make sure all nodes being used are part of the user's actual cloud
allocation broke the workflow of being able to use a custom inventory.
This commit fixes it.

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
