### PR TITLE
Update inventory after upstream rebase

### DIFF
--- a/ansible-ipi-install/inventory/jetski/hosts
+++ b/ansible-ipi-install/inventory/jetski/hosts
@@ -78,6 +78,10 @@ increase_bootstrap_timeout=2
 # (Optional) Increase install process timeout by N iterations.
 increase_install_timeout=2
 
+# (Optional) Disable RedFish inspection to intelligently choose between IPMI or RedFish protocol.
+# By default this feature is enabled and set to true. Uncomment below to disable and use IPMI.
+redfish_inspection=false
+
 ######################################
 # Vars regarding install-config.yaml #
 ######################################
@@ -123,7 +127,7 @@ network_type="OVNKubernetes"
 
 # (Optional) Disable BMC Certification Validation. When using self-signed certificates for your BMC, ensure to set to True.
 # Default value is False. 
-#disable_bmc_certificate_verification=True
+disable_bmc_certificate_verification=True
 
 # (Optional) OpenShift 4.6+, Set Root Device Hints to choose the proper device to install operating system on OpenShift nodes.
 # root device hint options include: ['deviceName','hctl','model','vendor','serialNumber','minSizeGigabytes','wwn','rotational']

--- a/ansible-ipi-install/inventory/shared_labs/hosts
+++ b/ansible-ipi-install/inventory/shared_labs/hosts
@@ -181,6 +181,10 @@ increase_bootstrap_timeout=2
 # (Optional) Increase install process timeout by N iterations.
 increase_install_timeout=2
 
+# (Optional) Disable RedFish inspection to intelligently choose between IPMI or RedFish protocol.
+# By default this feature is enabled and set to true. Uncomment below to disable and use IPMI.
+redfish_inspection=false
+
 ######################################
 # Vars regarding install-config.yaml #
 ######################################


### PR DESCRIPTION
This commit does two things:

1. Gets the new `redfish_inspection` option and sets it to
   false by default to force IPMI installs
2. Also `setsdisable_bmc_certificate_verification` to true
   to disable certificate verification if we switch to redfish
   in future.

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
