### PR TITLE
Add manifest file to enable OVN hybrid plugin

### DIFF
--- a/ansible-ipi-install/inventory/jetski/hosts
+++ b/ansible-ipi-install/inventory/jetski/hosts
@@ -82,6 +82,11 @@ increase_install_timeout=2
 # By default this feature is enabled and set to true. Uncomment below to disable and use IPMI.
 redfish_inspection=false
 
+# (Optional) Enable OVN hybirdOverlayConfig, it configures an additional overlay network for peers that are not using OVN.
+# This variable is valid only if network_type=OVNKubernetes
+# By default this is disabled and set to false. Set ovn_hybird_plugin to true to use BigIP ingress in a cluster.
+ovn_hybird_plugin=true
+
 ######################################
 # Vars regarding install-config.yaml #
 ######################################

--- a/ansible-ipi-install/inventory/shared_labs/hosts
+++ b/ansible-ipi-install/inventory/shared_labs/hosts
@@ -185,6 +185,11 @@ increase_install_timeout=2
 # By default this feature is enabled and set to true. Uncomment below to disable and use IPMI.
 redfish_inspection=false
 
+# (Optional) Enable OVN hybirdOverlayConfig, it configures an additional overlay network for peers that are not using OVN.
+# This variable is valid only if network_type=OVNKubernetes
+# By default this is disabled and set to false. Set ovn_hybird_plugin to true to use BigIP ingress in a cluster.
+ovn_hybird_plugin=true
+
 ######################################
 # Vars regarding install-config.yaml #
 ######################################

--- a/ansible-ipi-install/roles/shared-labs-prep/defaults/main.yml
+++ b/ansible-ipi-install/roles/shared-labs-prep/defaults/main.yml
@@ -2,3 +2,4 @@
 # defaults file for shared-labs-ocp4-prep
 worker_fqdns: []
 worker_bm_macs: []
+ovn_hybird_plugin: false

--- a/ansible-ipi-install/roles/shared-labs-prep/files/99_openshift-cluster-network.yaml
+++ b/ansible-ipi-install/roles/shared-labs-prep/files/99_openshift-cluster-network.yaml
@@ -1,0 +1,18 @@
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  creationTimestamp: null
+  name: cluster
+spec:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  externalIP:
+    policy: {}
+  networkType: OVNKubernetes
+  serviceNetwork:
+  - 172.30.0.0/16
+  defaultNetwork:
+    type: OVNKubernetes
+    ovnKubernetesConfig:
+      hybridOverlayConfig: {}

--- a/ansible-ipi-install/roles/shared-labs-prep/tasks/main.yml
+++ b/ansible-ipi-install/roles/shared-labs-prep/tasks/main.yml
@@ -293,14 +293,10 @@
       
     - name: Clean up any existing manifest content
       file:
-        path: "{{ manifest_path }}"
+        path: "{{ item }}"
         state: absent
-
-    - name: Create manifest directory
-      file:
-        path: "{{ manifest_path }}"
-        state: directory
-        mode: 0777
+      with_fileglob:
+        - "{{ manifest_path }}*"
 
     - name: Copy files to manifest path
       copy:

--- a/ansible-ipi-install/roles/shared-labs-prep/tasks/main.yml
+++ b/ansible-ipi-install/roles/shared-labs-prep/tasks/main.yml
@@ -285,6 +285,35 @@
       with_items: "{{ disable_nics }}"
   delegate_to: localhost
 
+- name: Create Manifest folder
+  block:
+    - name: Set manifest directory path
+      set_fact:
+        manifest_path: "{{ playbook_dir }}/roles/installer/files/manifests/"
+      
+    - name: Clean up any existing manifest content
+      file:
+        path: "{{ manifest_path }}"
+        state: absent
+
+    - name: Create manifest directory
+      file:
+        path: "{{ manifest_path }}"
+        state: directory
+        mode: 0777
+
+    - name: Copy files to manifest path
+      copy:
+        src: "{{ item }}"
+        dest: "{{ manifest_path }}/{{ item }}"
+        mode: 0644
+      with_items: 
+        - "99_openshift-cluster-network.yaml"
+      when:
+        - network_type == "OVNKubernetes" 
+        - ovn_hybird_plugin | bool     
+  delegate_to: localhost
+
 - name: Copy the approve_csr script from the local machine to the remote server
   copy:
     src: ./approve_csr.bash


### PR DESCRIPTION
# Description

This patch let user to enable OVN `hybridOverlayConfig` plugin in cluster, which enables additional overlay network for peers without OVN. This is mainly required for BigIP implementation.

Fixes #77 

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested in Alias Lab
- [ ] Test B

## Checklist

- [ ] I have performed a self-review of my own code
- [x] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
