### PR TITLE
Amd reservation

### DIFF
--- a/ansible-ipi-install/roles/bootstrap/defaults/main.yml
+++ b/ansible-ipi-install/roles/bootstrap/defaults/main.yml
@@ -4,6 +4,10 @@ alias:
     dell:
       740xd: 
         pub_nic: eno3
+      "7425":
+        pub_nic: eno3
+      "7525":
+        pub_nic: eno3
     supermicro:
       6029r:
         pub_nic: eno1

--- a/ansible-ipi-install/roles/bootstrap/tasks/10_load_inv.yml
+++ b/ansible-ipi-install/roles/bootstrap/tasks/10_load_inv.yml
@@ -99,7 +99,7 @@
       set_fact:
         provisioner_type: "{{ (lab_name == 'scale') | ternary(provisioner_hostname.split('.')[0].split('-')[3], provisioner_hostname.split('.')[0].split('-')[2]) }}"
  
-    - name: set povisioner_vendor
+    - name: set provisioner_vendor
       set_fact:
         provisioner_vendor: "{{ (provisioner_type in lab_vars['machine_types']['supermicro']) | ternary('supermicro', 'dell') }}"
   vars:
@@ -126,12 +126,6 @@
 - name: set fact for master mgmt
   set_fact:
     master_mgmts:  "{{ ocp_node_content| json_query('nodes[0:3].pm_addr')}}"
-
-- name: Set master FQDNs
-  set_fact:
-    master_fqdns: "{{ master_fqdns|default([]) + [ item |  replace('mgmt-','') | replace('-drac', '') ] }}"
-  with_items:
-    - "{{ master_mgmts }}"
 
 - name: Set worker count
   set_fact:
@@ -172,14 +166,31 @@
     msg: Required number of nodes are not available for workers
   when: worker_mgmts | length < worker_count | int
 
-# Needed in case where worker_mgmts is empty list, in that case worker_fdns fact is not set and there is a failure in set-deployment-facts role
-- name: Set fact for empty worker_fqdns
+# Needed in case where lists are constructed in a loop that might never be run 
+# if with_items list is empty
+- name: Set fact for empty zero worker
   set_fact:
+    worker_types: []
+    worker_vendors: []
+    master_types: []
+    dell_workers: []
+    supermicro_workers: []
+    dell_masters: []
+    supermicro_masters: []
+    ocp_fqdns: []
+    master_fqdns: []
     worker_fqdns: []
+    non_deploy_worker_fqdns: []
+
+- name: Set master FQDNs
+  set_fact:
+    master_fqdns: "{{ master_fqdns + [ item |  replace('mgmt-','') | replace('-drac', '') ] }}"
+  with_items:
+    - "{{ master_mgmts }}"
 
 - name: Set worker FQDNs
   set_fact:
-    worker_fqdns: "{{ worker_fqdns|default([]) + [ item |  replace('mgmt-','') | replace('-drac', '') ] }}"
+    worker_fqdns: "{{ worker_fqdns + [ item |  replace('mgmt-','') | replace('-drac', '') ] }}"
   with_items:
     - "{{ worker_mgmts }}"
 
@@ -189,14 +200,9 @@
   vars:
     query: nodes[{{worker_index}}:].pm_addr
 
-# Needed in case where worker_mgmts is empty list, in that case worker_fdns fact is not set and there is a failure in set-deployment-facts role
-- name: Set fact for empty non_deploy_worker_fqdns
-  set_fact:
-    non_deploy_worker_fqdns: []
-
 - name: Set non_deploy_worker FQDNs
   set_fact:
-    non_deploy_worker_fqdns: "{{ non_deploy_worker_fqdns|default([]) + [ item |  replace('mgmt-','') | replace('-drac', '') ] }}"
+    non_deploy_worker_fqdns: "{{ non_deploy_worker_fqdns + [ item |  replace('mgmt-','') | replace('-drac', '') ] }}"
   with_items:
     - "{{ non_deploy_worker_mgmts }}"
 
@@ -204,91 +210,94 @@
   block:
     - name: Set worker node types
       set_fact:
-        worker_types: "{{ worker_types | default([]) + [ (lab_name == 'scale') | ternary(item.split('.')[0].split('-')[3], item.split('.')[0].split('-')[2]) ] }}"
+        worker_types: "{{ worker_types + [ (lab_name == 'scale') | ternary(item.split('.')[0].split('-')[3], item.split('.')[0].split('-')[2]) ] }}"
       with_items:
         - "{{ worker_fqdns }}"
         - "{{ non_deploy_worker_fqdns }}"
 
     - name: Set worker node vendors
       set_fact:
-        worker_vendors: "{{ worker_vendors|default([]) + [(item in lab_vars['machine_types']['supermicro']) | ternary('supermicro', 'dell')] }}"
+        worker_vendors: "{{ worker_vendors + [(item in lab_vars['machine_types']['supermicro']) | ternary('supermicro', 'dell')] }}"
       with_items:
         - "{{ worker_types }}"
 
     - name: Set worker node dells (scale)
       set_fact:
-        dell_workers: "{{ dell_workers | default([]) + [ item ] }}"
+        dell_workers: "{{ dell_workers + [ item ] }}"
       with_items:
         - "{{ worker_fqdns }}"
       when: lab_name == 'scale' and item.split('.')[0].split('-')[3] in lab_vars['machine_types']['dell']
 
     - name: Set worker node dells (alias)
       set_fact:
-        dell_workers: "{{ dell_workers | default([]) + [ item ] }}"
+        dell_workers: "{{ dell_workers + [ item ] }}"
       with_items:
         - "{{ worker_fqdns }}"
       when: lab_name == 'alias' and item.split('.')[0].split('-')[2] in lab_vars['machine_types']['dell']
 
     - name: Set worker node supermicros (scale)
       set_fact:
-        supermicro_workers: "{{ supermicro_workers | default([]) + [ item ] }}"
+        supermicro_workers: "{{ supermicro_workers + [ item ] }}"
       with_items:
         - "{{ worker_fqdns }}"
       when: lab_name == 'scale' and item.split('.')[0].split('-')[3] in lab_vars['machine_types']['supermicro']
 
     - name: Set worker node supermicros (alias)
       set_fact:
-        supermicro_workers: "{{ supermicro_workers | default([]) + [ item ] }}"
+        supermicro_workers: "{{ supermicro_workers + [ item ] }}"
       with_items:
         - "{{ worker_fqdns }}"
       when: lab_name == 'alias' and item.split('.')[0].split('-')[2] in lab_vars['machine_types']['supermicro']
 
+    # there are always 3 masters so master_fqdns is always non-empty
+    # and loop will always be run so master_types is always defined
+ 
     - name: Set master node types
       set_fact:
-        master_types: "{{ master_types | default([]) + [ (lab_name == 'scale') | ternary(item.split('.')[0].split('-')[3], item.split('.')[0].split('-')[2]) ] }}"
+        master_types: "{{ master_types + [ (lab_name == 'scale') | ternary(item.split('.')[0].split('-')[3], item.split('.')[0].split('-')[2]) ] }}"
       with_items:
         - "{{ master_fqdns }}"
 
     - name: Set master node dells (scale)
       set_fact:
-        dell_masters: "{{ dell_masters | default([]) + [ item ] }}"
+        dell_masters: "{{ dell_masters + [ item ] }}"
       with_items:
         - "{{ master_fqdns }}"
       when: lab_name == 'scale' and item.split('.')[0].split('-')[3] in lab_vars['machine_types']['dell']
 
     - name: Set master node dells (alias)
       set_fact:
-        dell_masters: "{{ dell_masters | default([]) + [ item ] }}"
+        dell_masters: "{{ dell_masters + [ item ] }}"
       with_items:
         - "{{ master_fqdns }}"
       when: lab_name == 'alias' and item.split('.')[0].split('-')[2] in lab_vars['machine_types']['dell']
 
     - name: Set master node supermicros (scale)
       set_fact:
-        supermicro_masters: "{{ supermicro_masters | default([]) + [ item ] }}"
+        supermicro_masters: "{{ supermicro_masters + [ item ] }}"
       with_items:
         - "{{ master_fqdns }}"
       when: lab_name == 'scale' and item.split('.')[0].split('-')[3] in lab_vars['machine_types']['supermicro']
 
     - name: Set master node supermicros (alias)
       set_fact:
-        supermicro_masters: "{{ supermicro_masters | default([]) + [ item ] }}"
+        supermicro_masters: "{{ supermicro_masters + [ item ] }}"
       with_items:
         - "{{ master_fqdns }}"
       when: lab_name == 'alias' and item.split('.')[0].split('-')[2] in lab_vars['machine_types']['supermicro']
 
     - name: Set Dell nodes
       set_fact:
-        dell_nodes: "{{ dell_masters | default([]) + dell_workers | default([])  }}"
+        dell_nodes: "{{ dell_masters + dell_workers }}"
 
     - name: Set Supermicro nodes
       set_fact:
-        supermicro_nodes: "{{ supermicro_masters | default([]) + supermicro_workers | default([])  }}"
+        supermicro_nodes: "{{ supermicro_masters + supermicro_workers }}"
   vars:
     lab_vars: "{{ (lab_name == 'scale') | ternary(scale, alias) }}"
   when: lab_name in ['scale', 'alias']
 
-- name: Fail when masters are non homogenuous or don't match provisioner
+- name: Fail when masters are non homogeneous or don't match provisioner
   fail:
     msg: "Homogenuous nodes which match provisioner node are needed for masters"
   when: master_types | unique | length > 1 or master_types | unique != [provisioner_type]
@@ -304,7 +313,7 @@
 
 - name: Set ocp node FQDNs
   set_fact:
-    ocp_fqdns: "{{ ocp_fqdns|default([]) + [ item |  replace('mgmt-','') | replace('-drac', '') ] }}"
+    ocp_fqdns: "{{ ocp_fqdns + [ item |  replace('mgmt-','') | replace('-drac', '') ] }}"
   with_items:
     - "{{ ocp_mgmts }}"
 


### PR DESCRIPTION
# Description

Fixes issue #87
The first commit fixes the problem that the AMD server types were not defined in the inventory
so that various list vars in roles/bootstrap/tasks/10_load_inv.yml were not getting defined.

However, this exposed a bug in the with_items loops - if the loop body was never executed, the
assignment to the list variable was never done and so the list variable was undefined when referenced.
This problem was fixed by initializing such variables with a set_fact statement at the top, and
then removing the "default([])" filter from the loop body assignment statement.  This makes the code
more readable as well.

Finally, there is a check at the end for all masters being of same machine type as each other and 
same machine type as the provisioner host.   I was given a cloud for which this could never be true
(2 nodes were 7425 type, 2 were 7525 type).   I removed this constraint for now until we can understand 
what the constraint should be and why.

## Type of change

Please select the appropiate options:

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- tested code with Alias cloud12 as of Nov 30, it got much farther but encountered a Foreman permission problem unrelated to JetSki, doing this command, which I could run outside of JetSki and get the same error:
```
podman run hammercli hammer -u cloud12 -p bos@253  host update --name e20-h25-7425.alias.bos.scalelab.redhat.com --build 1 --operatingsystem 'RHEL 8.1' --medium 'RHEL 8.1' --partition-table 'ALIAS-Partition' --overwrite 1
```


**Test Configuration**:

- Versions: master branch as of Nov 30
- Hardware: Dell AMD servers e20-h25-7425, e20-h25-7425,  e20-h29-7525, e20-h31-7525
- all.yml changes:
```
cloud_name: cloud12
lab_name: alias
ansible_ssh_pass: password
version: "latest-4.6"
pullsecret: known-valid-pull-secret-gobbledygook
foreman_url: https://navi.alias.bos.scalelab.redhat.com
rebuild_provisioner: true
worker_count: 0
```
no inventory/jetski/hosts changes.

## Checklist

- [ x] I have performed a self-review of my own code

Yes. 

- [ x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.

issue 87 as stated above

- [x ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.

I've only tested on my cloud, so it needs review for sure.

- [ ] PRs should not be merged unless positively reviewed.
