### PR TITLE
patch for prov-master homogeneity constraint

### DIFF
--- a/ansible-ipi-install/roles/bootstrap/defaults/main.yml
+++ b/ansible-ipi-install/roles/bootstrap/defaults/main.yml
@@ -4,15 +4,20 @@ alias:
     dell:
       740xd: 
         pub_nic: eno3
+        prov_nic: eno2
       "7425":
         pub_nic: eno3
+        prov_nic: eno2
       "7525":
         pub_nic: eno3
+        prov_nic: eno2
     supermicro:
       6029r:
         pub_nic: eno1
+        prov_nic: enp130s0f1
       6048p:
         pub_nic: enp5s0f0
+        prov_nic: enp130s0f1
        
 scale:
   lab_url: "http://quads.rdu2.scalelab.redhat.com"
@@ -20,28 +25,41 @@ scale:
     supermicro:
       1029p:
         pub_nic: eno1
+        prov_nic: ens2f1
       1029u:
         pub_nic: eno1
       6048r:
         pub_nic: eno1
+        prov_nic: ens4s0f1
       5039ms:
         pub_nic: enp2s0f0
+        prov_nic: enp1s0f1
       6049p:
         pub_nic: ens5f0
+        prov_nic: ens3f1
       6018r:
         pub_nic: eno1
+        prov_nic: enp4s0f1
     dell:
       r620:
         pub_nic: eno3
+        prov_nic: enp66s0f3
       r630:
         pub_nic: enp3s0f0
+        prov_nic: eno2
       r730xd:
         pub_nic: em3
+        prov_nic: em2
       r720xd:
         pub_nic: em3
+        prov_nic: p4p2
       r930:
         pub_nic: em3
+        prov_nic: eno2
       fc640:
         pub_nic: eno1
+        prov_nic: ens2f0
       r640:
         pub_nic: eno1
+        prov_nic: ens1f1
+        prov_nic_f04: ens3f1

--- a/ansible-ipi-install/roles/bootstrap/tasks/10_load_inv.yml
+++ b/ansible-ipi-install/roles/bootstrap/tasks/10_load_inv.yml
@@ -304,9 +304,9 @@
     lab_vars: "{{ (lab_name == 'scale') | ternary(scale, alias) }}"
   when: lab_name in ['scale', 'alias']
 
-- name: Fail when masters are non homogeneous or don't match provisioner
+- name: Fail when masters are non homogeneous
   fail:
-    msg: "Homogenuous nodes which match provisioner node are needed for masters"
+    msg: "Master nodes should be Homogeneous, but identified these types - {{ master_types }}"
   when: master_types | unique | length > 1
 
 - name: Fail when worker nodes have R620s and R630s

--- a/ansible-ipi-install/roles/bootstrap/tasks/10_load_inv.yml
+++ b/ansible-ipi-install/roles/bootstrap/tasks/10_load_inv.yml
@@ -173,6 +173,7 @@
     worker_types: []
     worker_vendors: []
     master_types: []
+    master_vendors: []
     dell_workers: []
     supermicro_workers: []
     dell_masters: []
@@ -258,6 +259,12 @@
       with_items:
         - "{{ master_fqdns }}"
 
+    - name: Set master node vendors
+      set_fact:
+        master_vendors: "{{ master_vendors + [(item in lab_vars['machine_types']['supermicro']) | ternary('supermicro', 'dell')] }}"
+      with_items:
+        - "{{ master_types }}"
+
     - name: Set master node dells (scale)
       set_fact:
         dell_masters: "{{ dell_masters + [ item ] }}"
@@ -300,7 +307,7 @@
 - name: Fail when masters are non homogeneous or don't match provisioner
   fail:
     msg: "Homogenuous nodes which match provisioner node are needed for masters"
-  when: master_types | unique | length > 1 or master_types | unique != [provisioner_type]
+  when: master_types | unique | length > 1
 
 - name: Fail when worker nodes have R620s and R630s
   fail:

--- a/ansible-ipi-install/roles/network-discovery/tasks/main.yml
+++ b/ansible-ipi-install/roles/network-discovery/tasks/main.yml
@@ -34,6 +34,13 @@
   with_items:
     - "{{ ansible_eligible_interfaces }}"
 
+- name: Get the provisioning interface
+  set_fact:
+    prov_nic: "{{ item }}"
+  when: ansible_{{ item }}.macaddress is defined and ansible_{{ item }}.type == "ether" and ansible_{{ item }}.macaddress == prov_mac
+  with_items:
+    - "{{ ansible_eligible_interfaces }}"
+
 - name: Set lab_pub_nics for master
   set_fact:
     lab_pub_nics: []
@@ -54,19 +61,10 @@
         - "{{ worker_vendors }}"
         - "{{ worker_types }}"
 
-    - name: Set the provisioning interface
-      set_fact:
-        prov_nic: "{{ item }}"
-      with_items:
-        - "{{ ansible_eligible_interfaces }}"
-      when: 
-        - master_types | unique == [provisioner_type]
-        - ansible_{{ item }}.macaddress is defined and ansible_{{ item }}.type == "ether" and ansible_{{ item }}.macaddress == prov_mac
-
     - block:       
         - name: Set provisioning interface
           set_fact:
-            prov_nic: "{{ lab_vars['machine_types'][item.0][item.1]['prov_nic_f04'] if 'r640' in master_fqdns[0].split('.')[0].split('-') and 'f04' in master_fqdns[0].split('.')[0].split('-') else lab_vars['machine_types'][item.0][item.1]['prov_nic'] }}"
+            masters_prov_nic: "{{ lab_vars['machine_types'][item.0][item.1]['prov_nic_f04'] if 'r640' in master_fqdns[0].split('.')[0].split('-') and 'f04' in master_fqdns[0].split('.')[0].split('-') else lab_vars['machine_types'][item.0][item.1]['prov_nic'] }}"
           with_together: 
             - "{{ master_vendors }}"
             - "{{ master_types }}"
@@ -75,15 +73,12 @@
 
         - name: Echo provisioning interface
           debug:
-            msg: Script uses already defined Provisioning interface - {{ prov_nic }} for Supermicro 1029u models.
+            msg: Script using defined Provisioning interface - {{ masters_prov_nic }} from the inventory.
           when: 
             - ( '1029u' in master_types )
-          failed_when: prov_nic is not defined or prov_nic == ""
-          
+          failed_when: masters_prov_nic is not defined or masters_prov_nic == ""
       when: 
         - master_types | unique != [provisioner_type]
-        - master_types | unique | length == 1
-
   vars:
     lab_vars: "{{ (lab_name == 'scale') | ternary(scale, alias) }}"
   when: lab_name in ['scale', 'alias']

--- a/ansible-ipi-install/roles/network-discovery/tasks/main.yml
+++ b/ansible-ipi-install/roles/network-discovery/tasks/main.yml
@@ -34,24 +34,56 @@
   with_items:
     - "{{ ansible_eligible_interfaces }}"
 
-- name: Get the provisioning interface
-  set_fact:
-    prov_nic: "{{ item }}"
-  when: ansible_{{ item }}.macaddress is defined and ansible_{{ item }}.type == "ether" and ansible_{{ item }}.macaddress == prov_mac
-  with_items:
-    - "{{ ansible_eligible_interfaces }}"
-
 - name: Set lab_pub_nics for master
   set_fact:
-    lab_pub_nics: "{{ [lab_pub_nic] }}"
+    lab_pub_nics: []
 
-- name: Setting public nics for all workers
+- name: Setting public and prov nics 
   block:
-    - set_fact:
+    - name: Set master public nics
+      set_fact:
+        lab_pub_nics:  "{{ lab_pub_nics + [ lab_vars['machine_types'][item.0][item.1]['pub_nic'] ]  }}"
+      with_together: 
+        - "{{ master_vendors }}"
+        - "{{ master_types }}"
+
+    - name: Set worker public nics
+      set_fact:
         lab_pub_nics:  "{{ lab_pub_nics + [ lab_vars['machine_types'][item.0][item.1]['pub_nic'] ]  }}"
       with_together: 
         - "{{ worker_vendors }}"
         - "{{ worker_types }}"
+
+    - name: Set the provisioning interface
+      set_fact:
+        prov_nic: "{{ item }}"
+      with_items:
+        - "{{ ansible_eligible_interfaces }}"
+      when: 
+        - master_types | unique == [provisioner_type]
+        - ansible_{{ item }}.macaddress is defined and ansible_{{ item }}.type == "ether" and ansible_{{ item }}.macaddress == prov_mac
+
+    - block:       
+        - name: Set provisioning interface
+          set_fact:
+            prov_nic: "{{ lab_vars['machine_types'][item.0][item.1]['prov_nic_f04'] if 'r640' in master_fqdns[0].split('.')[0].split('-') and 'f04' in master_fqdns[0].split('.')[0].split('-') else lab_vars['machine_types'][item.0][item.1]['prov_nic'] }}"
+          with_together: 
+            - "{{ master_vendors }}"
+            - "{{ master_types }}"
+          when: 
+            - ( '1029u' not in master_types )
+
+        - name: Echo provisioning interface
+          debug:
+            msg: Script uses already defined Provisioning interface - {{ prov_nic }} for Supermicro 1029u models.
+          when: 
+            - ( '1029u' in master_types )
+          failed_when: prov_nic is not defined or prov_nic == ""
+          
+      when: 
+        - master_types | unique != [provisioner_type]
+        - master_types | unique | length == 1
+
   vars:
     lab_vars: "{{ (lab_name == 'scale') | ternary(scale, alias) }}"
   when: lab_name in ['scale', 'alias']

--- a/ansible-ipi-install/roles/set-deployment-facts/tasks/main.yml
+++ b/ansible-ipi-install/roles/set-deployment-facts/tasks/main.yml
@@ -5,6 +5,8 @@
      "{{ item }}": "{{ hostvars[groups['orchestration'][0]][item] }}"
   with_items:
     - master_fqdns
+    - master_types
+    - master_vendors
     - worker_fqdns
     - worker_types
     - worker_vendors
@@ -17,3 +19,4 @@
     - lab_ipmi_user
     - lab_ipmi_password
     - ocp_deploying_node_content
+    - provisioner_type


### PR DESCRIPTION
# Description

A minor patch to let user choose heterogeneous prov+master nodes within a cloud, now prov can be a non-telco class server.

Works for all model except SM 1029U due to different interface name for TRTP and TN10RT types so masters and prov should be the same unless there is a way to differentiate these models based on FQDN.

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested in scale lab

**Test Configuration**:

- Versions: OCP 4.7
- Hardware: Prov - SM 1029P  and Master 3 Dell FC640

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
