### PR TITLE
machine config to disable public nic

### DIFF
--- a/ansible-ipi-install/roles/shared-labs-prep/tasks/main.yml
+++ b/ansible-ipi-install/roles/shared-labs-prep/tasks/main.yml
@@ -263,35 +263,6 @@
     enabled: yes
   become: yes
 
-- name: Create fake root
-  block:
-    - name: Set fake root directory path
-      set_fact:
-        fake_root: "{{ playbook_dir }}/roles/installer/files/customize_filesystem/master"
-      
-    - name: Clean up any existing fake root content
-      file:
-        path: "{{ fake_root }}"
-        state: absent
-
-    - name: Set ifcfg path
-      set_fact:
-        ifcfg_path: "{{ fake_root }}/etc/sysconfig/network-scripts"
-
-    - name: Create fake root directory
-      file:
-        path: "{{ ifcfg_path }}"
-        state: directory
-        mode: 0777
-
-    - name: Create ifcfg files to disable NICs
-      template:
-        src: ocp4-lab.ifcfg-template.j2
-        dest: "{{ ifcfg_path }}/ifcfg-{{ item }}"
-        mode: 0644
-      with_items: "{{ disable_nics }}"
-  delegate_to: localhost
-
 - name: Create Manifest folder
   block:
     - name: Set manifest directory path
@@ -305,7 +276,18 @@
       with_fileglob:
         - "{{ manifest_path }}*"
 
-    - name: Copy files to manifest path
+    - name: Copy machine config file to Disable public nic
+      template:
+        src: ocp4-lab.machineconfig.yml.j2
+        dest: "{{ manifest_path }}/50-disable-lab-public-nic-{{ node_item }}.yaml"
+        mode: 0644
+      with_items:
+        - "master"
+        - "worker"
+      loop_control:
+          loop_var: node_item
+
+    - name: Copy OVN hybrid manifest files 
       copy:
         src: "{{ item }}"
         dest: "{{ manifest_path }}/{{ item }}"

--- a/ansible-ipi-install/roles/shared-labs-prep/templates/ocp4-lab.machineconfig.yml.j2
+++ b/ansible-ipi-install/roles/shared-labs-prep/templates/ocp4-lab.machineconfig.yml.j2
@@ -1,0 +1,24 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: {{ node_item }}
+  name: 50-disable-lab-public-nic-{{ node_item }}
+spec:
+  config:
+    ignition:
+{% if ((version.split('.')[0]|int == 4) and (version.split('.')[1]|int < 6)) %}
+      version: 2.2.0
+{% elif ((version.split('.')[0]|int == 4) and (version.split('.')[1]|int >= 6)) %}
+      version: 3.1.0
+{% endif %}
+    storage:
+      files:
+{% for nic in disable_nics  %}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,{{ lookup('template', 'ocp4-lab.ifcfg-template.j2', template_vars=dict(item=nic)) | b64encode }}
+        filesystem: root
+        mode: 0644
+        path: /etc/sysconfig/network-scripts/ifcfg-{{ nic }}
+{% endfor %}


### PR DESCRIPTION
# Description

Disable public nic to avoid DHCP conflicts using `MachineConfig` is the recommended way instead of `Ignition` file. Removing ignition file customization and adding new manifest file as described in issue.

Fixes #62 

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested in scale lab

**Test Configuration**:

- Versions: 4.7.0-0.nightly-2020-11-18-085225
- Hardware: Dell FC640

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
