### PR TITLE
OVN hybrid fix for 4.7 deployment

### DIFF
--- a/ansible-ipi-install/roles/shared-labs-prep/files/99_openshift-cluster-network.yaml
+++ b/ansible-ipi-install/roles/shared-labs-prep/files/99_openshift-cluster-network.yaml
@@ -15,4 +15,5 @@ spec:
   defaultNetwork:
     type: OVNKubernetes
     ovnKubernetesConfig:
-      hybridOverlayConfig: {}
+      hybridOverlayConfig: 
+        hybridClusterNetwork: []


### PR DESCRIPTION
# Description

4.7 nightly build fails with below network operator error if OVN hybrid plugin is enabled.

```
Error while trying to update operator configuration: could not update object (operator.openshift.io/v1, Kind=Network) /cluster: Network.operator.openshift.io "cluster" is invalid: spec.defaultNetwork.ovnKubernetesConfig.hybridOverlayConfig.hybridClusterNetwork: Invalid value: "null": spec.defaultNetwork.ovnKubernetesConfig.hybridOverlayConfig.hybridClusterNetwork in body must be of type array: "null"
```

Fixes # (issue)

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

- [x] Tested in scale lab

**Test Configuration**:

- Versions: 4.7.0-0.nightly-2020-12-14-080124
- Hardware: FC640

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
