### PR TITLE
Set worker_count deployment fact

### DIFF
--- a/ansible-ipi-install/roles/set-deployment-facts/tasks/main.yml
+++ b/ansible-ipi-install/roles/set-deployment-facts/tasks/main.yml
@@ -7,6 +7,7 @@
     - master_fqdns
     - master_types
     - master_vendors
+    - worker_count
     - worker_fqdns
     - worker_types
     - worker_vendors


### PR DESCRIPTION
Userful when worker_count is not defined in group_vars/all.yml
in which case it defaults to all nodes except first 3 which are used
as masters. The worker_count var is already set if undefined on the
orchestration host, this just sets the fact on the provisioner as well.

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
