### PR TITLE
reboot supermicro node once after set to pxe

### DIFF
--- a/ansible-ipi-install/roles/scale-node-prep/tasks/main.yml
+++ b/ansible-ipi-install/roles/scale-node-prep/tasks/main.yml
@@ -86,9 +86,32 @@
     - bootorder
 
 - name: Supermicro Boot order to PXE
-  shell: ipmitool -I lanplus -H mgmt-{{ item }} -U {{ lab_ipmi_user }} -P {{ lab_ipmi_password }} chassis bootdev pxe options=persistent
-  with_items:
-    - "{{ supermicro_nodes }}"
+  block:
+    - name: Boot order for legacy mode
+      shell: ipmitool -I lanplus -H mgmt-{{ item }} -U {{ lab_ipmi_user }} -P {{ lab_ipmi_password }} chassis bootdev pxe options=persistent
+      with_items:
+        - "{{ supermicro_nodes }}"
+      when:
+        - bootmode is defined
+        - bootmode == 'legacy'
+
+    - name: Boot order for UEFI mode
+      shell: ipmitool -I lanplus -H mgmt-{{ item }} -U {{ lab_ipmi_user }} -P {{ lab_ipmi_password }} raw 0x0 0x8 0x05 0xe0 0x04 0x0 0x0 0x0
+      with_items:
+        - "{{ supermicro_nodes }}"
+      when:
+        - ( bootmode is not defined ) or ( bootmode != 'legacy' )
+
+    - name: Power cycle supermicro nodes
+      shell: |
+        ipmitool -I lanplus -H mgmt-{{ item }} -U {{ lab_ipmi_user }} -P {{ lab_ipmi_password }} power cycle
+      with_items:
+        - "{{ supermicro_nodes }}"
+
+    - name: Wait for few seconds till it boots
+      wait_for:
+        timeout: 300
+
   when: supermicro_nodes | length > 0
   tags:
     - bootorder

--- a/ansible-ipi-install/roles/shared-labs-prep/tasks/main.yml
+++ b/ansible-ipi-install/roles/shared-labs-prep/tasks/main.yml
@@ -218,6 +218,17 @@
         - "{{ supermicro_nodes }}"
       when:
         - ( bootmode is not defined ) or ( bootmode != 'legacy' )
+
+    - name: Power cycle supermicro nodes
+      shell: |
+        ipmitool -I lanplus -H mgmt-{{ item }} -U {{ lab_ipmi_user }} -P {{ lab_ipmi_password }} power cycle
+      with_items:
+        - "{{ supermicro_nodes }}"
+
+    - name: Wait for few seconds till it boots
+      wait_for:
+        timeout: 300
+
   when: supermicro_nodes | length > 0
   tags:
     - bootorder


### PR DESCRIPTION
# Description

Recent trouble with Supermicro(few models/server) that the node is not PXE'ing consistently during Ironic inspection, this often happens during a redeployment of cluster. As a temporary workaround, power off the node before Jetski deployment helped in most of the cases.
It may be due to the Ironic PXE boot WITHOUT persistent option is not effective in some servers. 
This patch makes sure that server is set to PXE boot WITH persistent option by rebooting once before handing over the server to installer. 

Fixes # (issue)

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
