### PR TITLE
scaleup worker patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ _**Table of Contents**_
 
 This Ansible playbook and set of Ansible roles are aimed at providing a cluster of Red Hat OpenShift 4 (`IPI`) in the Red Hat shared labs with as little user input and intervention as possible.
 
+
 ## Prerequisites
 
 The playbook is intended to be run from outside the cluster of machines you wish to deploy on, from a host we will refer to as `jumphost` for the purposes of this discussion. It could even be a user's laptop or some Virtual Machine. The host from which the the playbook is run from (`jumphost`) must satisfy the following requirements
@@ -619,7 +620,6 @@ Sample `playbook-jetski-scaleup.yml`:
         - lab_ipmi_password
         - scale_worker_node
         - worker_count
-        - current_worker_count
 
 - hosts: provisioner
   roles:

--- a/ansible-ipi-install/playbook-jetski-scaleup.yml
+++ b/ansible-ipi-install/playbook-jetski-scaleup.yml
@@ -16,7 +16,6 @@
         - lab_ipmi_password
         - scale_worker_node
         - worker_count
-        - current_worker_count
         - dell_nodes
         - supermicro_nodes
         
@@ -27,7 +26,19 @@
 
 - name: Finishing IPI on Baremetal Installation 
   hosts: orchestration
-  tasks: 
+  tasks:
+    - block:
+        - name: Update ocp_nondeplopyed_node_content
+          set_fact:
+            ocp_deploying_node_content: "{{ ocp_deploying_node_content | combine({'nodes': ocp_deploying_node_content.nodes|difference(hostvars[groups['provisioner'][0]].failed_nodes)}, recursive=True) }}"
+
+        - name: Update ocp_nondeplopyed_node_content
+          set_fact:
+            nondeploying_worker_nodes_content: "{{ nondeploying_worker_nodes_content | combine({'nodes': nondeploying_worker_nodes_content.nodes|union(hostvars[groups['provisioner'][0]].failed_nodes)}, recursive=True) }}"
+      when:
+        - hostvars[groups['provisioner'][0]].failed_nodes is defined
+        - hostvars[groups['provisioner'][0]].failed_nodes | length > 0
+        
     - name: Writing Deployed node content to a file
       copy:
         dest: "{{ ocp_deployed_node_inv_path }}"

--- a/ansible-ipi-install/roles/scale-worker/tasks/10_bmc_secrets.yml
+++ b/ansible-ipi-install/roles/scale-worker/tasks/10_bmc_secrets.yml
@@ -1,11 +1,11 @@
 - name: Create BMC secret definition file for new worker
   copy:
-    dest: "{{ scaling_dir }}/worker-{{ ansible_loop.index0 + scale_worker_index | int }}-secret.yaml"
+    dest: "{{ scaling_dir }}/{{ item.host_name }}-secret.yaml"
     content: |
       apiVersion: v1
       kind: Secret
       metadata:
-        name: "worker-{{ ansible_loop.index0 + scale_worker_index | int }}-bmc-secret"
+        name: "{{ item.host_name }}-bmc-secret"
         namespace: openshift-machine-api
       type: Opaque      
       data:
@@ -19,7 +19,7 @@
   environment:
     KUBECONFIG: "{{ kubeconfig_file }}"
   shell: |
-    oc apply -f {{ scaling_dir }}/worker-{{ ansible_loop.index0 + scale_worker_index | int }}-secret.yaml
+    oc apply -f {{ scaling_dir }}/{{ item.host_name }}-secret.yaml
   loop: "{{ scale_worker_node.nodes }}"
   loop_control:
     extended: yes

--- a/ansible-ipi-install/roles/scale-worker/tasks/20_create_bmh.yml
+++ b/ansible-ipi-install/roles/scale-worker/tasks/20_create_bmh.yml
@@ -1,6 +1,6 @@
 - name: Create BareMetalHost definition file for new worker
   template:
-    dest: "{{ scaling_dir }}/worker-{{ ansible_loop.index0 + scale_worker_index | int }}-bmh.yaml"
+    dest: "{{ scaling_dir }}/{{ item.host_name }}-bmh.yaml"
     src: bare-metal-host.yaml.j2
   loop: "{{ scale_worker_node.nodes }}"
   loop_control:
@@ -10,7 +10,7 @@
   environment:
     KUBECONFIG: "{{ kubeconfig_file }}"
   shell: |
-    oc apply -f {{ scaling_dir }}/worker-{{ ansible_loop.index0 + scale_worker_index | int }}-bmh.yaml
+    oc apply -f {{ scaling_dir }}/{{ item.host_name }}-bmh.yaml
   loop: "{{ scale_worker_node.nodes }}"
   loop_control:
     extended: yes
@@ -23,12 +23,24 @@
   environment:
     KUBECONFIG: "{{ kubeconfig_file }}"
   shell: |
-    oc -n openshift-machine-api get bmh/worker-{{ ansible_loop.index0 + scale_worker_index | int }} --template={{'{{'}}.status.provisioning.state{{'}}'}}
+    oc -n openshift-machine-api get bmh/{{ item.host_name }} --template={{'{{'}}.status.provisioning.state{{'}}'}}
   register: bmh_node_ready
   retries: 30
   delay: 60
   until: bmh_node_ready.stdout.find("ready") != -1
   changed_when: bmh_node_ready.stdout_lines|length > 0
+  ignore_errors: true
   loop: "{{ scale_worker_node.nodes }}"
   loop_control:
     extended: yes
+
+- name: Set failed_nodes fact
+  set_fact:
+    failed_nodes: []
+
+- name: Find out if any failed nodes
+  set_fact:
+    failed_nodes: "{{ failed_nodes + [ item.item ] }}"
+  when: item.failed 
+  with_items: "{{ bmh_node_ready.results }}"
+

--- a/ansible-ipi-install/roles/scale-worker/tasks/30_scale_machinesets.yml
+++ b/ansible-ipi-install/roles/scale-worker/tasks/30_scale_machinesets.yml
@@ -10,7 +10,7 @@
   environment:
     KUBECONFIG: "{{ kubeconfig_file }}"
   shell: |
-    oc -n openshift-machine-api scale --replicas={{ worker_count }} machineset {{ worker_machineset.stdout }}
+    oc -n openshift-machine-api scale --replicas={{ worker_count | int - failed_nodes | length }} machineset {{ worker_machineset.stdout }}
 
 - name: wait for 20 minutes before checking for Machinesets 
   wait_for:
@@ -24,8 +24,8 @@
   register: mcp_machineset_ready
   retries: 30
   delay: 60
-  until: mcp_machineset_ready.stdout == "{{ worker_count }}"
-  changed_when: mcp_machineset_ready.stdout == "{{ worker_count }}"
+  until: mcp_machineset_ready.stdout == "{{ worker_count | int - failed_nodes | length }}"
+  changed_when: mcp_machineset_ready.stdout == "{{ worker_count | int - failed_nodes | length }}"
   
 - name: Wait for machineset to be ready
   environment:
@@ -35,5 +35,5 @@
   register: mcp_machineset_ready
   retries: 30
   delay: 60
-  until: mcp_machineset_ready.stdout == "{{ worker_count }}"
-  changed_when: mcp_machineset_ready.stdout == "{{ worker_count }}"
+  until: mcp_machineset_ready.stdout == "{{ worker_count | int - failed_nodes | length }}"
+  changed_when: mcp_machineset_ready.stdout == "{{ worker_count | int - failed_nodes | length }}"

--- a/ansible-ipi-install/roles/scale-worker/tasks/main.yml
+++ b/ansible-ipi-install/roles/scale-worker/tasks/main.yml
@@ -5,13 +5,6 @@
     state: directory
     path: "{{ scaling_dir }}/"
 
-- name: scale worker index
-  set_fact: 
-    scale_worker_index: "{{ current_worker_count | int }}"
-
-- debug:
-    msg: Scaling worker starts from - "{{ scale_worker_index }}" to "{{ worker_count }}"
-
 - name: Copy the approve_csr script from the local machine to the remote server
   copy:
     src: ./approve_csr.bash

--- a/ansible-ipi-install/roles/scale-worker/templates/bare-metal-host.yaml.j2
+++ b/ansible-ipi-install/roles/scale-worker/templates/bare-metal-host.yaml.j2
@@ -2,13 +2,13 @@
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
-  name: worker-{{ ansible_loop.index0 + scale_worker_index | int }}
+  name: {{ item.host_name }}
   namespace: openshift-machine-api
 spec:
   online: true
   bmc:
     address: "ipmi://{{ item.pm_addr }}:623"
-    credentialsName: "worker-{{ ansible_loop.index0 + scale_worker_index | int }}-bmc-secret"
+    credentialsName: "{{ item.host_name }}-bmc-secret"
   hardwareProfile: unknown
   bootMACAddress: "{{ item.prov_mac }}"
 {% if bootmode is defined and bootmode == 'legacy' %}


### PR DESCRIPTION
# Description

1. Consistent names for nodes and `BareMetalHost` resources suffixed with model number
2. Playbook will exclude if any nodes failed during `Introspection` stage and proceed with remaining nodes for `provisioning`
3. Updates `deployed` and `non-deployed` nodes accordingly so that failed nodes can be reattempted

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested in scale lab with a failed introspection and playbook proceeded with further nodes and scaled up
- [x] Re-ran playbook to include the failed node in to cluster. 

**Test Configuration**:

- Versions: 4.7.0 GA
- Hardware: Dell FC640

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
