### PR TITLE
fix ignition version logic

### DIFF
--- a/ansible-ipi-install/roles/shared-labs-prep/templates/ocp4-lab.machineconfig.yml.j2
+++ b/ansible-ipi-install/roles/shared-labs-prep/templates/ocp4-lab.machineconfig.yml.j2
@@ -8,9 +8,9 @@ metadata:
 spec:
   config:
     ignition:
-{% if ((version.split('.')[0]|int == 4) and (version.split('.')[1]|int < 6)) %}
+{% if ((version.split('.')[0]|int == 4 or version.split('.')[0] == 'latest-4') and (version.split('.')[1]|int < 6)) %}
       version: 2.2.0
-{% elif ((version.split('.')[0]|int == 4) and (version.split('.')[1]|int >= 6)) %}
+{% elif ((version.split('.')[0]|int == 4 or version.split('.')[0] == 'latest-4') and (version.split('.')[1]|int >= 6)) %}
       version: 3.1.0
 {% endif %}
     storage:


### PR DESCRIPTION
# Description

Error in `if` condition to identify the release when the version is set to `latest-*`, this affect ignition file generation  due to invalid machine configuration file.

```sh
Failed to create "50-disable-lab-public-nic-master.yaml" machineconfigs.v1.machineconfiguration.openshift.io/50-disable-lab-public-nic-master -n : MachineConfig.machineconfiguration.openshift.io "50-disable-lab-public-nic-master" is invalid: spec.config.ignition: Required value
```

Fixes # (issue)

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
