### PR TITLE
Rescue badfish tasks

### DIFF
--- a/ansible-ipi-install/roles/scale-node-prep/tasks/main.yml
+++ b/ansible-ipi-install/roles/scale-node-prep/tasks/main.yml
@@ -66,21 +66,16 @@
         - "{{ dell_nodes }}"
       register: wait_for_idrac
       until: wait_for_idrac is succeeded
-      retries: 20
+      retries: 10
       delay: 30
+      ignore_errors: true
 
-    - name: Set nodes to director boot order (Dell)
-      shell:
-        chdir: "{{ badfish_tempdir.path }}"
-        cmd: |
-          source {{ badfish_venv }}/bin/activate
-          {{ badfish_cmd }}{{ item }} -t director
+    - include_role:
+        name: shared-labs-prep
+        tasks_from: 20_set_director_mode.yml
       with_items:
         - "{{ dell_nodes }}"
-      register: boot_order
-      until: boot_order is succeeded
-      retries: 3
-      delay: 60
+
   when: dell_nodes | length > 0
   tags:
     - bootorder

--- a/ansible-ipi-install/roles/shared-labs-prep/tasks/20_set_director_mode.yml
+++ b/ansible-ipi-install/roles/shared-labs-prep/tasks/20_set_director_mode.yml
@@ -1,0 +1,30 @@
+- name: Set Director
+  block:
+    - name: Set nodes to director boot order (Dell)
+      shell:
+        chdir: "{{ badfish_tempdir.path }}"
+        cmd: |
+          source {{ badfish_venv }}/bin/activate
+          {{ badfish_cmd }}{{ item }} -t director
+      register: boot_order
+      until: boot_order is succeeded
+      retries: 3
+      delay: 60
+  rescue:
+    - name: Rescue - Reset iDRAC - {{ item }}
+      shell: |
+        sshpass -p "{{ lab_ipmi_password }}" ssh -o StrictHostKeyChecking=no {{ lab_ipmi_user }}@mgmt-{{ item }} "racadm racreset soft -f"
+
+    - pause:
+        seconds: 300
+
+    - name: Set nodes to director boot order (Dell)
+      shell:
+        chdir: "{{ badfish_tempdir.path }}"
+        cmd: |
+          source {{ badfish_venv }}/bin/activate
+          {{ badfish_cmd }}{{ item }} -t director
+      register: boot_order_re
+      until: boot_order_re is succeeded
+      retries: 5
+      delay: 60

--- a/ansible-ipi-install/roles/shared-labs-prep/tasks/main.yml
+++ b/ansible-ipi-install/roles/shared-labs-prep/tasks/main.yml
@@ -183,21 +183,14 @@
         - "{{ dell_nodes }}"
       register: wait_for_idrac
       until: wait_for_idrac is succeeded
-      retries: 20
+      retries: 10
       delay: 30
+      ignore_errors: true
 
-    - name: Set nodes to director boot order (Dell)
-      shell:
-        chdir: "{{ badfish_tempdir.path }}"
-        cmd: |
-          source {{ badfish_venv }}/bin/activate
-          {{ badfish_cmd }}{{ item }} -t director
+    - include_tasks: 20_set_director_mode.yml
       with_items:
         - "{{ dell_nodes }}"
-      register: boot_order
-      until: boot_order is succeeded
-      retries: 3
-      delay: 60
+
   when: dell_nodes | length > 0
   tags:
     - bootorder


### PR DESCRIPTION
# Description

Badfish command to set Director boot order occasionally fails due to iDRAC problem, its better to attempt a racreset and re-apply boot order with in rescue tasks rather than failing entire play. 
Sometime this failure gets in to a loop at each execution for different server and never cross this prep task.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
