### PR TITLE
r640 pub if name change

### DIFF
--- a/ansible-ipi-install/roles/bootstrap/defaults/main.yml
+++ b/ansible-ipi-install/roles/bootstrap/defaults/main.yml
@@ -61,7 +61,7 @@ scale:
         pub_nic: eno1
         prov_nic: ens2f0
       r640:
-        pub_nic: eno1
+        pub_nic: eno1np0
         prov_nic: ens1f1
         prov_nic_f04: ens3f1
 

--- a/ansible-ipi-install/roles/network-discovery/tasks/main.yml
+++ b/ansible-ipi-install/roles/network-discovery/tasks/main.yml
@@ -50,6 +50,11 @@
   set_fact:
     lab_pub_nics: []
 
+- name: Set lab_pub_nics for master
+  set_fact:
+    lab_pub_nics: ["eno1"]
+  when: ( "'r640' in master_types" ) or ( "'r640' in worker_types" )
+
 - name: Setting public and prov nics 
   block:
     - name: Set master public nics


### PR DESCRIPTION
# Description

Fix to handle R640 public interface name discrepancy for Mellanox NIC. This fix will disable both `eno1` as well as `eno1np0` for R640 nodes.
https://projects.engineering.redhat.com/browse/SCALELAB-1116

Fixes # (issue)

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested on F04 R640 nodes 
- [x] Tested on other racks. 

**Test Configuration**:

- Versions: 4.7.7
- Hardware: R640

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
