### PR TITLE
Bump RHEL version on provisioner

### DIFF
--- a/ansible-ipi-install/roles/bootstrap/tasks/20_reprovision_nodes.yml
+++ b/ansible-ipi-install/roles/bootstrap/tasks/20_reprovision_nodes.yml
@@ -20,7 +20,7 @@
 
 - name: set os_install
   set_fact:
-    os_install: "{{ (rebuild_provisioner or rhel_version is version('8.1', '<')) | ternary('RHEL 8.1', false) }}"
+    os_install: "{{ (rebuild_provisioner or rhel_version is version('8.3', '<')) | ternary('RHEL 8.3', false) }}"
 
 - name: Determine if containers should be used
   set_fact:


### PR DESCRIPTION
OCp 4.8 installer seems to require a version of libvirt
that is available in RHEL 8.3. Bumping to RHEL 8.3 for all
versions as it should previous versions should also work on RHEL 8.3.

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
