### PR TITLE
moved scaleup result files to provisioner node

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The purpose served by each role can be summarized as follows:
 * `installer` - Actually drives the OpenShift Installer. This role runs on the provisioner host.
 
 Scale Up worker roles
-* `scale-bootstrap` - This role is similar to **boostrap**, but runs only during scale up worker playbook execution, it is responsible for gathering inventory details from the local file `ocpdeployednodeinv.json` and `ocpnondeployednodeinv.json`. It validates the input `worker_count` with the available non deployed nodes.
+* `scale-bootstrap` - This role is similar to **boostrap**, but runs only during scale up worker playbook execution, it is responsible for gathering inventory details from the file `ocpdeployednodeinv.json` and `ocpnondeployednodeinv.json`. It validates the input `worker_count` with the available non deployed nodes.
 * `scale-node-prep` - This role is similar to **shared-labs-prep**, runs only during scale up worker playbook execution, it is responsible for setting up the boot order on the new worker nodes.
 * `scale-worker` - This is the main role which does all openshift operations, it creates BMC scecret, BMH objects for new host and scale worker machinesets. 
 
@@ -213,7 +213,8 @@ The tree structure is shown below:
     │       └── main.yml
     ├── scale-bootstrap
     │   └── tasks
-    │       └── main.yml
+    │       ├── main.yml
+    │       └── 10_load_old_inv.yml
     ├── scale-node-prep
     │   ├── tasks
     │   │   └── main.yml
@@ -542,23 +543,28 @@ Sample `playbook-jetski.yml`:
     no_proxy: "{{ no_proxy_list }}"
 
 - name: Finishing IPI on Baremetal Installation 
-  hosts: orchestration
+  hosts: provisioner
   tasks: 
-    - name: create ocpdeployednodeinv.json file
+    - name: Create directory
+      file:
+        state: directory
+        path: "{{ ansible_facts['user_dir'] }}/scale-worker"
+
+    - name: Writing Deployed node content to a file
       copy:
-        dest: "{{ ocp_deployed_node_inv_path }}"
+        dest: "{{ ansible_facts['user_dir'] }}/scale-worker/ocpdeployednodeinv.json"
         content: "{{ ocp_deploying_node_content | to_nice_json }}"
       when: ocp_deploying_node_content.nodes | length > 0   
 
-    - name: create ocpnondeployednodeinv.json file
+    - name: Writing available non Deployed node content to a file
       copy:
-        dest: "{{ ocp_nondeployed_node_inv_path }}"
+        dest: "{{ ansible_facts['user_dir'] }}/scale-worker/ocpnondeployednodeinv.json"
         content: "{{ nondeploying_worker_nodes_content | to_nice_json }}"
       when: nondeploying_worker_nodes_content.nodes | length > 0
 
-    - name: Delete ocpnondeployednodeinv.json file
+    - name: Deleting non Deployed node content
       file:
-        dest: "{{ ocp_nondeployed_node_inv_path }}"
+        dest: "{{ ansible_facts['user_dir'] }}/scale-worker/ocpnondeployednodeinv.json"
         state: absent
       when: nondeploying_worker_nodes_content.nodes | length == 0    
 ```
@@ -574,7 +580,7 @@ $ ansible-playbook -i inventory/jetski/hosts playbook-jetski.yml
 
 ## Verifying Installation
 
-Once the playbook has successfully completed, verify that your environment is up and running. Please keep `ocpdeployednodeinv.json` and `ocpnondeployednodeinv.json` files in `ansible-ipi-install` incase if you want to scale up workers later.
+Once the playbook has successfully completed, verify that your environment is up and running. 
 
 1. Log into the provisioner node (typically the first node in you lab assignment)
 
@@ -600,7 +606,7 @@ worker-0.openshift.example.com               Ready    worker          19h   v1.1
 ```
 ### The Ansible `playbook-jetski-scaleup.yml`
 
-This playbook scales up worker nodes to the desired `worker_count` mentioned in `ansible-ipi-install/group_vars/all.yml` make sure to update the worker_count before execution. It must be executed from the same ansible jump host (ansible machine which is used to deploy the fresh cluster using `playbook-jetski.yml`) and from the same directory because it refers to `ocpdeployednodeinv.json` and `ocpnondeployednodeinv.json`(originally created by `playbook-jetski.yml`) present inside `ansible-ipi-install`directory. 
+This playbook scales up worker nodes to the desired `worker_count` mentioned in `ansible-ipi-install/group_vars/all.yml` make sure to update the worker_count before execution. This playbook reads the current cluster size and available nodes from `ocpdeployednodeinv.json` and `ocpnondeployednodeinv.json`(originally created by `playbook-jetski.yml`) stored in provisioner node `/home/kni/scale-worker/` directory. 
 
 Sample `playbook-jetski-scaleup.yml`:
 
@@ -610,7 +616,6 @@ Sample `playbook-jetski-scaleup.yml`:
   hosts: orchestration
   roles:
     - { role: scale-bootstrap }
-    - { role: add-provisioner }
 
 - hosts: provisioner
   tasks:
@@ -623,32 +628,48 @@ Sample `playbook-jetski-scaleup.yml`:
         - lab_ipmi_password
         - scale_worker_node
         - worker_count
-
+        - dell_nodes
+        - supermicro_nodes
+        - ocp_deploying_node_content
+        - nondeploying_worker_nodes_content
+        
 - hosts: provisioner
   roles:
-    #    - { role: scale-node-prep }
+    - { role: scale-node-prep }
     - { role: scale-worker }
 
 - name: Finishing IPI on Baremetal Installation 
-  hosts: orchestration
-  tasks: 
-    - name: create ocpdeployednodeinv.json file
+  hosts: provisioner
+  tasks:
+    - block:
+        - name: Update ocp_nondeplopyed_node_content
+          set_fact:
+            ocp_deploying_node_content: "{{ ocp_deploying_node_content | combine({'nodes': ocp_deploying_node_content.nodes|difference(failed_nodes)}, recursive=True) }}"
+
+        - name: Update ocp_nondeplopyed_node_content
+          set_fact:
+            nondeploying_worker_nodes_content: "{{ nondeploying_worker_nodes_content | combine({'nodes': nondeploying_worker_nodes_content.nodes|union(failed_nodes)}, recursive=True) }}"
+      when:
+        - failed_nodes is defined
+        - failed_nodes | length > 0
+        
+    - name: Writing Deployed node content to a file
       copy:
-        dest: "{{ ocp_deployed_node_inv_path }}"
+        dest: "{{ ansible_facts['user_dir'] }}/scale-worker/ocpdeployednodeinv.json"
         content: "{{ ocp_deploying_node_content | to_nice_json }}"
       when: ocp_deploying_node_content.nodes | length > 0   
 
-    - name: create ocpnondeployednodeinv.json file
+    - name: Writing available non Deployed node content to a file
       copy:
-        dest: "{{ ocp_nondeployed_node_inv_path }}"
+        dest: "{{ ansible_facts['user_dir'] }}/scale-worker/ocpnondeployednodeinv.json"
         content: "{{ nondeploying_worker_nodes_content | to_nice_json }}"
       when: nondeploying_worker_nodes_content.nodes | length > 0
 
-    - name: Delete ocpnondeployednodeinv.json file
+    - name: Deleting non Deployed node content
       file:
-        dest: "{{ ocp_nondeployed_node_inv_path }}"
+        dest: "{{ ansible_facts['user_dir'] }}/scale-worker/ocpnondeployednodeinv.json"
         state: absent
-      when: nondeploying_worker_nodes_content.nodes | length == 0        
+      when: nondeploying_worker_nodes_content.nodes | length == 0
 ```
 
 
@@ -784,7 +805,7 @@ Wait till you the see the cluster back to normal state with reduced worker node,
 This approach will not work if you want to rebuild a node after a successful playbook execution, because after a successful execution `ocpnondeployednodeinv.json` will be update to latest or removed. 
 Re-run might use the update inventory.
 
-### Pulblic Routable API
+### Public Routable API
 
 By default the the Kuberentes API is only accessible from the provisioner node as the cluster does not have any lab routable IPs and the IPs are only routable from within the cluster. Along with your allocation in Scale Lab, you are able to request for  public routable IP addresses, in which case you can use the `routable_api` option to access your baremetal cluster from outside on the lab/provosioner host as long as you are on VPN. To do this, you need to set `routable_api` in `group_vars/all.yml` to `true` and along with that the `inventory/jetski/hosts` has to use the information from http://wiki.rdu2.scalelab.redhat.com/vlans/ for your cloud and look like below.
 

--- a/ansible-ipi-install/playbook-jetski-scaleup.yml
+++ b/ansible-ipi-install/playbook-jetski-scaleup.yml
@@ -3,7 +3,6 @@
   hosts: orchestration
   roles:
     - { role: scale-bootstrap }
-    - { role: add-provisioner }
 
 - hosts: provisioner
   tasks:
@@ -18,6 +17,8 @@
         - worker_count
         - dell_nodes
         - supermicro_nodes
+        - ocp_deploying_node_content
+        - nondeploying_worker_nodes_content
         
 - hosts: provisioner
   roles:
@@ -25,34 +26,34 @@
     - { role: scale-worker }
 
 - name: Finishing IPI on Baremetal Installation 
-  hosts: orchestration
+  hosts: provisioner
   tasks:
     - block:
         - name: Update ocp_nondeplopyed_node_content
           set_fact:
-            ocp_deploying_node_content: "{{ ocp_deploying_node_content | combine({'nodes': ocp_deploying_node_content.nodes|difference(hostvars[groups['provisioner'][0]].failed_nodes)}, recursive=True) }}"
+            ocp_deploying_node_content: "{{ ocp_deploying_node_content | combine({'nodes': ocp_deploying_node_content.nodes|difference(failed_nodes)}, recursive=True) }}"
 
         - name: Update ocp_nondeplopyed_node_content
           set_fact:
-            nondeploying_worker_nodes_content: "{{ nondeploying_worker_nodes_content | combine({'nodes': nondeploying_worker_nodes_content.nodes|union(hostvars[groups['provisioner'][0]].failed_nodes)}, recursive=True) }}"
+            nondeploying_worker_nodes_content: "{{ nondeploying_worker_nodes_content | combine({'nodes': nondeploying_worker_nodes_content.nodes|union(failed_nodes)}, recursive=True) }}"
       when:
-        - hostvars[groups['provisioner'][0]].failed_nodes is defined
-        - hostvars[groups['provisioner'][0]].failed_nodes | length > 0
+        - failed_nodes is defined
+        - failed_nodes | length > 0
         
     - name: Writing Deployed node content to a file
       copy:
-        dest: "{{ ocp_deployed_node_inv_path }}"
+        dest: "{{ ansible_facts['user_dir'] }}/scale-worker/ocpdeployednodeinv.json"
         content: "{{ ocp_deploying_node_content | to_nice_json }}"
       when: ocp_deploying_node_content.nodes | length > 0   
 
     - name: Writing available non Deployed node content to a file
       copy:
-        dest: "{{ ocp_nondeployed_node_inv_path }}"
+        dest: "{{ ansible_facts['user_dir'] }}/scale-worker/ocpnondeployednodeinv.json"
         content: "{{ nondeploying_worker_nodes_content | to_nice_json }}"
       when: nondeploying_worker_nodes_content.nodes | length > 0
 
     - name: Deleting non Deployed node content
       file:
-        dest: "{{ ocp_nondeployed_node_inv_path }}"
+        dest: "{{ ansible_facts['user_dir'] }}/scale-worker/ocpnondeployednodeinv.json"
         state: absent
       when: nondeploying_worker_nodes_content.nodes | length == 0

--- a/ansible-ipi-install/playbook-jetski.yml
+++ b/ansible-ipi-install/playbook-jetski.yml
@@ -33,22 +33,27 @@
     no_proxy: "{{ no_proxy_list }}"
 
 - name: Finishing IPI on Baremetal Installation 
-  hosts: orchestration
+  hosts: provisioner
   tasks: 
+    - name: Create directory
+      file:
+        state: directory
+        path: "{{ ansible_facts['user_dir'] }}/scale-worker"
+
     - name: Writing Deployed node content to a file
       copy:
-        dest: "{{ ocp_deployed_node_inv_path }}"
+        dest: "{{ ansible_facts['user_dir'] }}/scale-worker/ocpdeployednodeinv.json"
         content: "{{ ocp_deploying_node_content | to_nice_json }}"
       when: ocp_deploying_node_content.nodes | length > 0   
 
     - name: Writing available non Deployed node content to a file
       copy:
-        dest: "{{ ocp_nondeployed_node_inv_path }}"
+        dest: "{{ ansible_facts['user_dir'] }}/scale-worker/ocpnondeployednodeinv.json"
         content: "{{ nondeploying_worker_nodes_content | to_nice_json }}"
       when: nondeploying_worker_nodes_content.nodes | length > 0
 
     - name: Deleting non Deployed node content
       file:
-        dest: "{{ ocp_nondeployed_node_inv_path }}"
+        dest: "{{ ansible_facts['user_dir'] }}/scale-worker/ocpnondeployednodeinv.json"
         state: absent
       when: nondeploying_worker_nodes_content.nodes | length == 0 

--- a/ansible-ipi-install/roles/bootstrap/tasks/10_load_inv.yml
+++ b/ansible-ipi-install/roles/bootstrap/tasks/10_load_inv.yml
@@ -9,8 +9,6 @@
     "{{ item.name }}": "{{ playbook_dir +  '/' + item.path if inventory_hostname == 'localhost' else inventory_tempdir.path + '/' + item.path }}"
   with_items:
     - { name: ocpinv_file, path: ocpinv.json }
-    - { name: ocp_deployed_node_inv_path, path: ocpdeployednodeinv.json }
-    - { name: ocp_nondeployed_node_inv_path, path: ocpnondeployednodeinv.json }
 
 - name: check ocpinv file available
   stat:

--- a/ansible-ipi-install/roles/scale-bootstrap/tasks/10_load_old_inv.yml
+++ b/ansible-ipi-install/roles/scale-bootstrap/tasks/10_load_old_inv.yml
@@ -1,0 +1,52 @@
+- name: Regather facts for provisioner
+  setup:
+  delegate_to: "{{ groups['provisioner'][0] }}"
+
+- name: check  ocp_deployed_node_inv_path file available
+  stat:
+    path: "{{ ansible_facts['user_dir'] }}/scale-worker/ocpdeployednodeinv.json"
+  register: deploy_node
+  delegate_to: "{{ groups['provisioner'][0] }}"
+
+- name: check ocp_nondeployed_node_inv_path file available
+  stat:
+    path: "{{ ansible_facts['user_dir'] }}/scale-worker/ocpnondeployednodeinv.json"
+  register: nondeploy_node
+  delegate_to: "{{ groups['provisioner'][0] }}"
+
+- name: Fail when required JSON files are missing
+  fail:
+    msg: Input JSON - file is missing or No available nodes to scale
+  when: ( not deploy_node.stat.exists ) or ( not nondeploy_node.stat.exists )
+  delegate_to: "{{ groups['provisioner'][0] }}"
+
+- name: read non deployed node file
+  slurp:
+    src: "{{ ansible_facts['user_dir'] }}/scale-worker/ocpnondeployednodeinv.json"
+  register: nondeploy_inv
+  delegate_to: "{{ groups['provisioner'][0] }}"
+
+- name: set inventory fact
+  set_fact:
+    ocp_nondeployed_node_content: "{{ nondeploy_inv['content'] | b64decode | from_json }}"
+  delegate_to: "{{ groups['provisioner'][0] }}"
+  delegate_facts: True
+
+- name: read deployed node file
+  slurp:
+    src: "{{ ansible_facts['user_dir'] }}/scale-worker/ocpdeployednodeinv.json"
+  register: deploy_inv
+  delegate_to: "{{ groups['provisioner'][0] }}"
+
+- name: set inventory fact
+  set_fact:
+    ocp_deployed_node_content: "{{ deploy_inv['content'] | b64decode | from_json }}"
+  delegate_to: "{{ groups['provisioner'][0] }}"
+  delegate_facts: True
+
+- name: copy facts
+  set_fact:
+    "{{ item }}": "{{ hostvars[groups['provisioner'][0]][item] }}"
+  with_items:
+    - ocp_deployed_node_content
+    - ocp_nondeployed_node_content

--- a/ansible-ipi-install/roles/scale-bootstrap/tasks/main.yml
+++ b/ansible-ipi-install/roles/scale-bootstrap/tasks/main.yml
@@ -9,60 +9,11 @@
     "{{ item.name }}": "{{ playbook_dir +  '/' + item.path if inventory_hostname == 'localhost' else inventory_tempdir.path + '/' + item.path }}"
   with_items:
     - { name: ocpinv_file, path: ocpinv.json }
-    - { name: ocp_deployed_node_inv_path, path: ocpdeployednodeinv.json }
-    - { name: ocp_nondeployed_node_inv_path, path: ocpnondeployednodeinv.json }
-
-- name: check  ocp_deployed_node_inv_path file available
-  stat:
-      path: "{{ ocp_deployed_node_inv_path }}"
-  register: deploy_node
-
-- name: check ocp_nondeployed_node_inv_path file available
-  stat:
-      path: "{{ ocp_nondeployed_node_inv_path }}"
-  register: nondeploy_node
-
-- name: Fail when required JSON files are missing
-  fail:
-    msg: Input JSON - file is missing or No available nodes to scale
-  when: ( not deploy_node.stat.exists ) or ( not nondeploy_node.stat.exists )
 
 - name: read inv env file
   slurp:
     src: "{{ ocpinv_file }}"
   register: invfile
-
-- name: read non deployed node file
-  slurp:
-    src: "{{ ocp_nondeployed_node_inv_path }}"
-  register: nondeploy_inv
-
-- name: set inventory fact
-  set_fact:
-    ocp_nondeployed_node_content: "{{ nondeploy_inv['content'] | b64decode | from_json }}"
-
-- name: read non deployed node file
-  slurp:
-    src: "{{ ocp_deployed_node_inv_path }}"
-  register: deploy_inv
-
-- name: set inventory fact
-  set_fact:
-    ocp_deployed_node_content: "{{ deploy_inv['content'] | b64decode | from_json }}"
-
-- name: Set default deployed worker count
-  set_fact:
-    deployed_worker_fqdns: []
-
-- name: Set already deployed worker count
-  set_fact:
-    deployed_worker_fqdns: "{{ deployed_worker_fqdns | default([]) + [ item.pm_addr ] }}"
-  when: "'worker' in item.host_name"
-  loop: "{{ ocp_deployed_node_content.nodes }}"
-  
-- name: Existing worker count
-  set_fact:
-    current_worker_count: "{{ deployed_worker_fqdns | length }}"
 
 - name: set inventory fact
   set_fact:
@@ -90,6 +41,26 @@
       set_fact:
         lab_ipmi_user:  "{{ ocpinv_content.nodes[prov_index|int].pm_user }}"
         lab_ipmi_password:  "{{ ocpinv_content.nodes[prov_index|int].pm_password }}"
+
+- include_role:
+    name: add-provisioner
+    tasks_from: main.yml
+
+- include_tasks: 10_load_old_inv.yml
+
+- name: Set default deployed worker count
+  set_fact:
+    deployed_worker_fqdns: []
+
+- name: Set already deployed worker count
+  set_fact:
+    deployed_worker_fqdns: "{{ deployed_worker_fqdns | default([]) + [ item.pm_addr ] }}"
+  when: "'worker' in item.host_name"
+  loop: "{{ ocp_deployed_node_content.nodes }}"
+  
+- name: Existing worker count
+  set_fact:
+    current_worker_count: "{{ deployed_worker_fqdns | length }}"
 
 - name: Set scale worker count
   set_fact:

--- a/ansible-ipi-install/roles/set-deployment-facts/tasks/main.yml
+++ b/ansible-ipi-install/roles/set-deployment-facts/tasks/main.yml
@@ -18,6 +18,7 @@
     - lab_ipmi_user
     - lab_ipmi_password
     - ocp_deploying_node_content
+    - nondeploying_worker_nodes_content
     - provisioner_type
     - prov_index
 


### PR DESCRIPTION
# Description

Airflow CI job runs within a short-living pod and we can't really use them to store JetSki created files(ocpdeployed.json & ocpnondeployed.json) to scaleup worker later. 
This change will now create and store the files directly in the provisioner node, so it can be accessible from any ansible host/pod. 

Fixes # (issue)

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
