### PR TITLE
changing badfish cmd

### DIFF
--- a/ansible-ipi-install/roles/bootstrap/tasks/20_reprovision_nodes.yml
+++ b/ansible-ipi-install/roles/bootstrap/tasks/20_reprovision_nodes.yml
@@ -129,7 +129,7 @@
 
         - name: Power on Provisioner if powered off (Dell and not in container)
           shell: |
-            {{ badfish_cmd_container }}{{ provisioner_hostname }} --power-on
+            {{ badfish_cmd }}{{ provisioner_hostname }} --power-on
           when: provisioner_vendor == "dell" and not 'On' in power_state.stdout
 
         - name: Wait for node to be powered on (Dell and not in container)


### PR DESCRIPTION
# Description

Task should not use `badfish_cmd_container` , it should be `badfish_cmd` Failed install when this task needed to be ran.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

I have tested this new code in cloud28 via Airflow deployment utilizing JetSki of my this fork from cloud40

