### PR TITLE
networkmanager keyfile to disable interfaces

### DIFF
--- a/ansible-ipi-install/roles/shared-labs-prep/templates/ocp4-lab.machineconfig.yml.j2
+++ b/ansible-ipi-install/roles/shared-labs-prep/templates/ocp4-lab.machineconfig.yml.j2
@@ -23,11 +23,11 @@ spec:
         filesystem: root
         mode: 0644
         path: /etc/sysconfig/network-scripts/ifcfg-{{ nic }}
+{% endfor %}
 {% if (version.split('.')[1]|int >= 8) %}
       - contents:
-          source: data:text/plain;charset=utf-8;base64,{{ lookup('template', 'ocp4-lab.nm.conf.j2', template_vars=dict(item=nic)) | b64encode }}
+          source: data:text/plain;charset=utf-8;base64,{{ lookup('template', 'ocp4-lab.nm.conf.j2', template_vars=dict(disable_nics=disable_nics)) | b64encode }}
         filesystem: root
         mode: 0644
-        path: /etc/NetworkManager/conf.d/99-disable-nics-{{ nic }}.conf
+        path: /etc/NetworkManager/conf.d/99-disable-nics.conf
 {% endif %}
-{% endfor %}

--- a/ansible-ipi-install/roles/shared-labs-prep/templates/ocp4-lab.machineconfig.yml.j2
+++ b/ansible-ipi-install/roles/shared-labs-prep/templates/ocp4-lab.machineconfig.yml.j2
@@ -8,10 +8,12 @@ metadata:
 spec:
   config:
     ignition:
-{% if ((version.split('.')[0]|int == 4 or version.split('.')[0] == 'latest-4') and (version.split('.')[1]|int < 6)) %}
+{% if (version.split('.')[0]|int == 4 or version.split('.')[0] == 'latest-4' or version.split('.')[0] == 'stable-4') %}
+{% if (version.split('.')[1]|int < 6) %}
       version: 2.2.0
-{% elif ((version.split('.')[0]|int == 4 or version.split('.')[0] == 'latest-4') and (version.split('.')[1]|int >= 6)) %}
+{% elif (version.split('.')[1]|int >= 6) %}
       version: 3.1.0
+{% endif %}
 {% endif %}
     storage:
       files:
@@ -21,4 +23,11 @@ spec:
         filesystem: root
         mode: 0644
         path: /etc/sysconfig/network-scripts/ifcfg-{{ nic }}
+{% if (version.split('.')[1]|int >= 8) %}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,{{ lookup('template', 'ocp4-lab.nm.conf.j2', template_vars=dict(item=nic)) | b64encode }}
+        filesystem: root
+        mode: 0644
+        path: /etc/NetworkManager/conf.d/99-disable-nics-{{ nic }}.conf
+{% endif %}
 {% endfor %}

--- a/ansible-ipi-install/roles/shared-labs-prep/templates/ocp4-lab.nm.conf.j2
+++ b/ansible-ipi-install/roles/shared-labs-prep/templates/ocp4-lab.nm.conf.j2
@@ -1,0 +1,2 @@
+[keyfile]
+unmanaged-devices=interface-name:{{ item }}

--- a/ansible-ipi-install/roles/shared-labs-prep/templates/ocp4-lab.nm.conf.j2
+++ b/ansible-ipi-install/roles/shared-labs-prep/templates/ocp4-lab.nm.conf.j2
@@ -1,2 +1,2 @@
 [keyfile]
-unmanaged-devices=interface-name:{{ item }}
+unmanaged-devices={% for nic in disable_nics %}interface-name:{{ nic }}{{ ";" if not loop.last }}{% endfor %}

--- a/ansible-ipi-install/roles/shared-labs-prep/templates/ocp4-lab.sctp-module.yaml.j2
+++ b/ansible-ipi-install/roles/shared-labs-prep/templates/ocp4-lab.sctp-module.yaml.j2
@@ -6,7 +6,8 @@ metadata:
 spec:
   config:
     ignition:
-{% if ((version.split('.')[0]|int == 4 or version.split('.')[0] == 'latest-4') and (version.split('.')[1]|int >= 6)) %}
+{% if (version.split('.')[0]|int == 4 or version.split('.')[0] == 'latest-4' or version.split('.')[0] == 'stable-4') %}
+{% if (version.split('.')[1]|int >= 6) %}    
       version: 3.1.0
     storage:
       files:
@@ -20,7 +21,7 @@ spec:
           overwrite: true
           contents:
             source: data:,sctp
-{% elif ((version.split('.')[0]|int == 4 or version.split('.')[0] == 'latest-4') and (version.split('.')[1]|int < 6)) %}
+{% elif (version.split('.')[1]|int < 6) %}
       version: 2.2.0
     storage:
       files:
@@ -35,4 +36,5 @@ spec:
           filesystem: root
           mode: 420
           path: /etc/modules-load.d/sctp-load.conf
+{% endif %}
 {% endif %}


### PR DESCRIPTION
# Description

Additional `NetworkManager` configuration to unmanage all the unwanted interfaces, as describe in the bz https://bugzilla.redhat.com/show_bug.cgi?id=1984708

Manifest file would be like,

```
---
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfig
metadata:
  labels:
    machineconfiguration.openshift.io/role: master
  name: 50-disable-lab-public-nic-master
spec:
  config:
    ignition:
      version: 3.1.0
    storage:
      files:
      - contents:
          source: data:text/plain;charset=utf-8;base64,REVWSUNFPWVubzEKQk9PVFBST1RPPW5vbmUKT05CT09UPW5vCg==
        filesystem: root
        mode: 0644
        path: /etc/sysconfig/network-scripts/ifcfg-eno1
      - contents:
          source: data:text/plain;charset=utf-8;base64,W2tleWZpbGVdCnVubWFuYWdlZC1kZXZpY2VzPWludGVyZmFjZS1uYW1lOmVubzEK
        filesystem: root
        mode: 0644
        path: /etc/NetworkManager/conf.d/99-disable-nics-eno1.conf
```

Fixes # (issue)

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Testing 4.8 GA Build in ALIAS
- [ ] Test B

**Test Configuration**:

- Versions: 4.8.0 GA
- Hardware: Dell 740xd

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
