### PR TITLE
corrects broken ci.openshift.org URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ ansible_ssh_pass: password
 ansible_ssh_key: "{{ ansible_user_dir }}/.ssh/id_rsa"
 # The version of the openshift-installer, undefined or empty results in the playbook failing with error message.
 # Values accepted: 'latest-4.3', 'latest-4.4', explicit version i.e. 4.3.0-0.nightly-2019-12-09-035405
-# For reference, https://openshift-release.svc.ci.openshift.org/
+# For reference, https://amd64.ocp.releases.ci.openshift.org/ and https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/
 version: "4.4.4"
 # Enter whether the build should use 'dev' (nightly builds) or 'ga' for Generally Available version of OpenShift
 # Empty value results in playbook failing with error message.

--- a/ansible-ipi-install/group_vars/all.yml
+++ b/ansible-ipi-install/group_vars/all.yml
@@ -8,7 +8,7 @@ ansible_ssh_pass: password
 ansible_ssh_key: "{{ ansible_user_dir }}/.ssh/id_rsa"
 # The version of the openshift-installer, undefined or empty results in the playbook failing with error message.
 # Values accepted: 'latest-4.3', 'latest-4.4', explicit version i.e. 4.3.0-0.nightly-2019-12-09-035405
-# For reference, https://openshift-release.svc.ci.openshift.org/
+# For reference, https://amd64.ocp.releases.ci.openshift.org/ and https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/
 version: "4.4.4"
 # Enter whether the build should use 'dev' (nightly builds) or 'ga' for Generally Available version of OpenShift
 # Empty value results in playbook failing with error message.

--- a/documentation/ipi-install/modules/ipi-install-upstream-select-an-openshift-installer-release-from-ci-development.adoc
+++ b/documentation/ipi-install/modules/ipi-install-upstream-select-an-openshift-installer-release-from-ci-development.adoc
@@ -10,7 +10,7 @@
 
 .Procedure
 
-. Go to https://openshift-release.svc.ci.openshift.org/[Release Status] and choose a release
+. Go to https://amd64.ocp.releases.ci.openshift.org/[Release Status] and choose a release
 that has passed the tests for metal.
 
 . Verify that the release is available in the OpenShift mirror


### PR DESCRIPTION
# Description

URLs in documentation for ci.openshift.org were broken after app.ci was decommissioned about April 2021. This replaces those URLs with working ones.

Fixes #202 

## Type of change

Please select the appropriate options:

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ x ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ x ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ x ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
