### PR TITLE
Remove podman module

### DIFF
--- a/ansible-ipi-install/roles/bootstrap/tasks/20_reprovision_nodes.yml
+++ b/ansible-ipi-install/roles/bootstrap/tasks/20_reprovision_nodes.yml
@@ -36,13 +36,6 @@
             state: present
           become: true
 
-        - name: Get Badfish pod image
-          podman_image:
-            name: "{{ badfish_pod_image }}"
-            pull: yes
-            force: yes
-          when: provisioner_vendor == "dell"
-
         - name: Build the hammercli image
           shell: podman build --build-arg foreman_url={{ foreman_url }} -t hammercli .
           args:

--- a/ansible-ipi-install/roles/bootstrap/vars/main.yml
+++ b/ansible-ipi-install/roles/bootstrap/vars/main.yml
@@ -1,4 +1,4 @@
 badfish_pod_image: "quay.io/quads/badfish"
-badfish_cmd_container: "podman run -it --rm --dns {{ dns_server }} {{ badfish_pod_image }} -u {{ lab_ipmi_user }} -p {{ lab_ipmi_password }} -i config/idrac_interfaces.yml -H mgmt-"
+badfish_cmd_container: "podman run --pull=always -it --rm --dns {{ dns_server }} {{ badfish_pod_image }} -u {{ lab_ipmi_user }} -p {{ lab_ipmi_password }} -i config/idrac_interfaces.yml -H mgmt-"
 badfish_cmd: "/root/badfish/src/badfish/badfish.py -u {{ lab_ipmi_user }} -p {{ lab_ipmi_password }} -i /root/badfish/config/idrac_interfaces.yml -H mgmt-"
 


### PR DESCRIPTION
# Description

As stated at https://github.com/redhat-performance/JetSki/issues/226#issuecomment-1180491616, we can remove this task since the Badfish image is already pulled as part of `podman run`. Also adding the flag `--pull=always` to emulate the previous behavior that had `force: true`

Fixes #226 

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [x] PRs should not be merged unless positively reviewed.
