### PR TITLE
Use udev to disable public NICs on startup

### DIFF
--- a/ansible-ipi-install/roles/shared-labs-prep/templates/ocp4-lab.machineconfig.yml.j2
+++ b/ansible-ipi-install/roles/shared-labs-prep/templates/ocp4-lab.machineconfig.yml.j2
@@ -30,4 +30,9 @@ spec:
         filesystem: root
         mode: 0644
         path: /etc/NetworkManager/conf.d/99-disable-nics.conf
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,{{ lookup('template', 'ocp4-lab.udev-pubnics.rules.j2', template_vars=dict(disable_nics=disable_nics)) | b64encode }}
+        filesystem: root
+        mode: 0644
+        path: /etc/udev/rules.d/71-disable-public-nics.rules
 {% endif %}

--- a/ansible-ipi-install/roles/shared-labs-prep/templates/ocp4-lab.udev-pubnics.rules.j2
+++ b/ansible-ipi-install/roles/shared-labs-prep/templates/ocp4-lab.udev-pubnics.rules.j2
@@ -1,0 +1,3 @@
+{% for nic in disable_nics  %}
+ACTION=="add", SUBSYSTEM=="net", ENV{INTERFACE}=="{{ nic }}", RUN+="/bin/sh -c 'echo 1 > /sys$DEVPATH/device/remove'"
+{% endfor %}


### PR DESCRIPTION
# Description

Deployment of OCP on r650 hardware was having issues with IP assignment on the private and public interfaces, required for the lab setup.
It seems that during startup RHCOS configures all interfaces using DHCP. Configuring the public NIC as unmanaged by NetworkManager later during statup does not have the desired effect. We therefore disable the public NIC with a new udev rule.

Fixes # (issue)

## Type of change

Please select the appropriate options:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Test on r650 for OCP 4.10 and 4.11 by @sferlin 

**Test Configuration**:

- Versions: 4.10 and 4.11
- Hardware: r650

## Checklist

- [X] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
