### PR TITLE
fix set os_install error

### DIFF
--- a/ansible-ipi-install/roles/bootstrap/tasks/20_reprovision_nodes.yml
+++ b/ansible-ipi-install/roles/bootstrap/tasks/20_reprovision_nodes.yml
@@ -14,7 +14,7 @@
 
 - name: set rhel version
   set_fact:
-    rhel_current_version: "{{ rhel_release.stdout.split()[-2] }}"
+    rhel_current_version: "{{ rhel_release.stdout.split('release')[1].split()[0] }}"
   ignore_errors: true
   when: rhel_release.stdout | length > 0
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes errors that look like this when there is a space in the release name

```
[2022-08-30, 19:21:08 UTC] {subprocess.py:92} INFO - TASK [bootstrap : set os_install] **********************************************
[2022-08-30, 19:21:08 UTC] {subprocess.py:92} INFO - Tuesday 30 August 2022  19:21:08 +0000 (0:00:00.049)       0:00:16.153 ********
[2022-08-30, 19:21:08 UTC] {subprocess.py:92} INFO - [0;31mfatal: [localhost]: FAILED! => {"msg": "Version comparison failed: '<' not supported between instances of 'str' and 'int'"}[0m
```

## Type of change

Please select the appropriate options:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
