### PR TITLE
Boost deployment time

### DIFF
--- a/ansible-ipi-install/ansible.cfg
+++ b/ansible-ipi-install/ansible.cfg
@@ -1,7 +1,8 @@
 [defaults]
 inventory=./inventory
 remote_user=kni
-callback_whitelist = profile_tasks
+callbacks_enabled=profile_tasks
+pipelining=true
 
 [privilege_escalation]
 become_method=sudo

--- a/ansible-ipi-install/roles/installer/tasks/59_power_off_cluster_servers.yml
+++ b/ansible-ipi-install/roles/installer/tasks/59_power_off_cluster_servers.yml
@@ -12,17 +12,25 @@
         - "{{ groups.masters }}"
         - "{{ groups.workers | default([]) }}"
 
-    - name: Power off hosts
-      ipmi_power:
+    - name: Power off hosts - async
+      community.general.ipmi_power:
         name: "{{ hostvars[item]['ipmi_address'] }}"
         user: "{{ hostvars[item]['ipmi_user'] }}"
         password: "{{ hostvars[item]['ipmi_password'] }}"
         port: "{{ hostvars[item]['ipmi_port'] | default(623) }}"
         state: off
+      async: 180
+      poll: 0
       register: power_off_hosts
-      until: power_off_hosts is not failed
+      loop: "{{ groups['poweroff_hosts'] }}"
+      when: groups['poweroff_hosts'] is defined
+
+    - name: Check for async task to finish
+      async_status:
+        jid: "{{ item.ansible_job_id }}"
+      loop: "{{ power_off_hosts.results }}"
+      register: async_poll_results
+      until: async_poll_results.finished
       retries: 10
       delay: 5
-      with_items: "{{ groups['poweroff_hosts'] }}"
-      when: groups['poweroff_hosts'] is defined
   tags: powerservers

--- a/ansible-ipi-install/roles/shared-labs-prep/tasks/10_redfish_queue.yml
+++ b/ansible-ipi-install/roles/shared-labs-prep/tasks/10_redfish_queue.yml
@@ -1,12 +1,17 @@
-- name: Redfish job queue
-  block:
-    - name: Clear redfish job queues - {{ item }}
-      shell: "{{ badfish_podman_cmd }}{{ item }} --clear-jobs --force"
-      register: clear_jobs
-      until: clear_jobs is succeeded
-      retries: 3
-      delay: 30
-  rescue:
-    - name: Rescue - Reset iDRAC - {{ item }}
-      shell: |
-        sshpass -p "{{ lab_ipmi_password }}" ssh -o StrictHostKeyChecking=no {{ lab_ipmi_user }}@mgmt-{{ item }} "racadm racreset soft -f"
+- name: Clear redfish job queues from Dell nodes - async
+  shell: |
+    "{{ badfish_podman_cmd }}{{ item }} --clear-jobs --force" ||
+    sshpass -p "{{ lab_ipmi_password }}" ssh -o StrictHostKeyChecking=no {{ lab_ipmi_user }}@mgmt-{{ item }} "racadm racreset soft -f"
+  async: 60
+  poll: 0
+  register: async_loop
+  loop: "{{ dell_nodes }}"
+
+- name: Wait for async task to finish
+  async_status:
+    jid: "{{ item.ansible_job_id }}"
+  delay: 1
+  retries: 10
+  loop: "{{async_loop.results}}"
+  register: async_loop_jobs
+  until: async_loop_jobs.finished

--- a/ansible-ipi-install/roles/shared-labs-prep/tasks/20_set_director_mode.yml
+++ b/ansible-ipi-install/roles/shared-labs-prep/tasks/20_set_director_mode.yml
@@ -1,22 +1,18 @@
-- name: Set Director
-  block:
-    - name: Set nodes to director boot order (Dell)
-      shell: "{{ badfish_podman_cmd }}{{ item }} -t director"
-      register: boot_order
-      until: boot_order is succeeded
-      retries: 3
-      delay: 60
-  rescue:
-    - name: Rescue - Reset iDRAC - {{ item }}
-      shell: |
-        sshpass -p "{{ lab_ipmi_password }}" ssh -o StrictHostKeyChecking=no {{ lab_ipmi_user }}@mgmt-{{ item }} "racadm racreset soft -f"
+- name: Set nodes to director boot order (Dell) - async
+  shell: |
+    {{ badfish_podman_cmd }}{{ item }} -t director ||
+    sshpass -p "{{ lab_ipmi_password }}" ssh -o StrictHostKeyChecking=no {{ lab_ipmi_user }}@mgmt-{{ item }} "racadm racreset soft -f" &&
+    {{ badfish_podman_cmd }}{{ item }} -t director
+  async: 300
+  poll: 0
+  register: async_loop
+  loop: "{{ dell_nodes }}"
 
-    - pause:
-        seconds: 300
-
-    - name: Set nodes to director boot order (Dell)
-      shell: "{{ badfish_podman_cmd }}{{ item }} -t director"
-      register: boot_order_re
-      until: boot_order_re is succeeded
-      retries: 5
-      delay: 60
+- name: Wait for async task to finish
+  async_status:
+    jid: "{{ item.ansible_job_id }}"
+  delay: 1
+  retries: 30
+  loop: "{{async_loop.results}}"
+  register: async_loop_jobs
+  until: async_loop_jobs.finished

--- a/ansible-ipi-install/roles/shared-labs-prep/tasks/main.yml
+++ b/ansible-ipi-install/roles/shared-labs-prep/tasks/main.yml
@@ -132,39 +132,34 @@
     - "{{ pub_nic }}"
   become: yes
 
-- name: Power on master nodes
-  ipmi_power:
-    name: "mgmt-{{ item }}"
-    user: "{{ lab_ipmi_user }}"
-    password: "{{ lab_ipmi_password }}"
-    state: on
-  with_items: "{{ master_fqdns }}"
-  register: power_on_masters
-  until: power_on_masters is succeeded
-  retries: 3
-  delay: 30
-  tags:
-    - bootorder
+- block:
 
-- name: Power on worker nodes
-  ipmi_power:
-    name: "mgmt-{{ item }}"
-    user: "{{ lab_ipmi_user }}"
-    password: "{{ lab_ipmi_password }}"
-    state: on
-  with_items: "{{ worker_fqdns }}"
-  register: power_on_workers
-  until: power_on_workers is succeeded
-  retries: 3
-  delay: 30
+  - name: Power on nodes - async
+    community.general.ipmi_power:
+      name: mgmt-{{ item }}
+      user: "{{ lab_ipmi_user }}"
+      password: "{{ lab_ipmi_password }}"
+      state: on
+    async: 30
+    poll: 0
+    register: async_loop
+    loop: "{{ master_fqdns + worker_fqdns }}"
+
+  - name: Wait for async action to finish
+    async_status:
+      jid: "{{ item.ansible_job_id }}"
+    delay: 1
+    retries: 10
+    loop: "{{async_loop.results}}"
+    register: async_loop_jobs
+    until: async_loop_jobs.finished
+
   tags:
     - bootorder
 
 - name: Dell Boot Order tasks (Dell)
   block:
     - include_tasks: 10_redfish_queue.yml
-      with_items:
-        - "{{ dell_nodes }}"
 
     - name: Wait for iDrac to be responsive (check via --check-boot for Dell) 
       shell: "{{ badfish_podman_cmd }}{{ item }} --check-boot"
@@ -177,8 +172,6 @@
       ignore_errors: true
 
     - include_tasks: 20_set_director_mode.yml
-      with_items:
-        - "{{ dell_nodes }}"
 
   when: dell_nodes | length > 0
   tags:
@@ -206,10 +199,6 @@
         ipmitool -I lanplus -H mgmt-{{ item }} -U {{ lab_ipmi_user }} -P {{ lab_ipmi_password }} power cycle
       with_items:
         - "{{ supermicro_nodes }}"
-
-    - name: Wait for few seconds till it boots
-      wait_for:
-        timeout: 300
 
   when: supermicro_nodes | length > 0
   tags:
@@ -357,7 +346,7 @@
   when: worker_count != 0
 
 - name: Power off remaining workers
-  ipmi_power:
+  community.general.ipmi_power:
     name: "{{ item.pm_addr }}"
     user: "{{ lab_ipmi_user }}"
     password: "{{ lab_ipmi_password }}"


### PR DESCRIPTION
# Description

In order to cut down deployment time of new clusters, several tasks, that take a few minutes, can be executed in parallel with the help of the async statement, and then we can poll them with async_status.

Deployment time of a 6 node cluster (3 masters + 3 workers) seen with the original code was:
Thursday 06 October 2022  21:17:21 +0000 (0:00:00.402)       **1:32:37.115** ******                                                                                                                                                               

With the patch was:
Monday 10 October 2022  12:15:55 +0000 (0:00:00.397)       **1:15:51.220** ********

That means a time saving of ~15minutes

Also updating ansible.cfg to enable pipelining and replace the deprecated callback_whitelist by callbacks_enabled to suppress deprecation warnings in the output.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update


## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
