### PR TITLE
Removing Ansible as a package dep.

### DIFF
--- a/ansible-ipi-install/roles/shared-labs-prep/vars/main.yml
+++ b/ansible-ipi-install/roles/shared-labs-prep/vars/main.yml
@@ -13,7 +13,6 @@ yum_packages:
   - python3-requests
   - sshpass
   - make
-  - ansible
 rdo_packages:
   - https://trunk.rdoproject.org/rhel8-master/deps/latest/Packages/python3-crypto-2.6.1-18.el8ost.x86_64.rpm
   - https://trunk.rdoproject.org/rhel8-master/deps/latest/Packages/python3-pyghmi-1.0.22-2.el8ost.noarch.rpm


### PR DESCRIPTION
You can't run ansible without is already being installed. There are some packaging dep conflicts in installing ansible from RPMs on RHEL in the shared labs. This requirement will always hit that problem. Since ansible has to be already installed to get to this point there's no reason for it to be required here. If it's been installed by pip instead of RPM then the deploy can't continue.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
