### PR TITLE
Fix hammercli dockerfile

### DIFF
--- a/ansible-ipi-install/roles/bootstrap/files/Dockerfile
+++ b/ansible-ipi-install/roles/bootstrap/files/Dockerfile
@@ -1,5 +1,9 @@
 FROM quay.io/centos/centos:8
 ARG foreman_url=https://foreman.example.com
+
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 RUN dnf install -y epel-release \
         python3
 


### PR DESCRIPTION
# Description

The Dockerfile fails to build because the mirror **https://mirror.centos.org** is not available anymore  and so when trying to build it throws the error
`CentOS Linux 8 - AppStream                       18  B/s |  38  B     00:02    
Error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
Error: error building at STEP "RUN dnf install -y epel-release         python3": error while running runtime: exit status 1
`
The PR sets alternative mirror instead so that the Dockerfile builds successfully.


## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] While trying to build the dockerfile using `podman build -t hammercli . ` the issue arises which is fixed when setting the alternative mirror for centos to http://vault.centos.org 

