### PR TITLE
Network discovery updates for newer ansible

### DIFF
--- a/ansible-ipi-install/roles/network-discovery/tasks/main.yml
+++ b/ansible-ipi-install/roles/network-discovery/tasks/main.yml
@@ -23,26 +23,21 @@
 # Need to do this as the ansible facts per interface use the naming convention with _ and not -
 - name: Set eligible interfaces list
   set_fact:
-    ansible_eligible_interfaces: "{{ ansible_eligible_interfaces | default([]) + [item | replace('-','_')] }}"
+    ansible_eligible_interfaces: "{{ ansible_eligible_interfaces | default([]) + [ansible_facts[item | replace('-','_')]] }}"
   with_items:
     - "{{ ansible_interfaces }}"
 
-# Remove vlaned interfaces from eligible list
-- name: Removing vlaned interfaces
-  set_fact:
-    ansible_eligible_interfaces: "{{ ansible_eligible_interfaces | reject('search', '[.]') | list }}"
-
 - name: Get the bm interface
   set_fact:
-    pub_nic: "{{ item }}"
-  when: ansible_{{ item }}.macaddress is defined and ansible_{{ item}}.type == "ether" and ansible_{{ item }}.macaddress == bm_mac
+    pub_nic: "{{ item.device }}"
+  when: item.macaddress is defined and item.type == "ether" and item.macaddress == bm_mac
   with_items:
     - "{{ ansible_eligible_interfaces }}"
 
 - name: Get the provisioning interface
   set_fact:
-    prov_nic: "{{ item }}"
-  when: ansible_{{ item }}.macaddress is defined and ansible_{{ item }}.type == "ether" and ansible_{{ item }}.macaddress == prov_mac
+    prov_nic: "{{ item.device }}"
+  when: item.macaddress is defined and item.type == "ether" and item.macaddress == prov_mac
   with_items:
     - "{{ ansible_eligible_interfaces }}"
 


### PR DESCRIPTION
# Description

Updates to network discovery to avoid templating within conditionals.
Used with ansible core 2.16.2
