### PR TITLE
Enable bmh firmware options

### DIFF
--- a/ansible-ipi-install/inventory/jetski/hosts
+++ b/ansible-ipi-install/inventory/jetski/hosts
@@ -135,9 +135,9 @@ extcidrnet6="fd01:1101::/64"
 # NOTE: For the RH shared labs, the VIPs below are automated w/ variables
 #       based on the extcidrnet above.
 
-# An IP reserved on the baremetal network. 
+# An IP reserved on the baremetal network.
 dnsvip="{{ extcidrnet | next_nth_usable(2) }}"
-# An IP reserved on the baremetal network for the API endpoint. 
+# An IP reserved on the baremetal network for the API endpoint.
 # (Optional) If not set, a DNS lookup verifies that api.<clustername>.<domain> provides an IP
 apivip="{{ extcidrnet | next_nth_usable(3) }}"
 # An IP reserved on the baremetal network for the Ingress endpoint.
@@ -171,8 +171,13 @@ disable_bmc_certificate_verification=True
 #provisioningHostIP=<baremetal_net_IP1>
 #bootstrapProvisioningIP=<baremetal_net_IP2>
 
-# (Optional) Change the boot mode of the OpenShift cluster nodes to legacy mode (BIOS). Default is UEFI. 
+# (Optional) Change the boot mode of the OpenShift cluster nodes to legacy mode (BIOS). Default is UEFI.
 bootmode=legacy
+
+# (Optional) Change some BIOS settings for the OpenShift cluster nodes.
+#sriov=true
+#multithread=true
+#virtualization=true
 
 # (Optional) OpenShift 4.6+, Set Root Device Hints to choose the proper device to install operating system on OpenShift nodes.
 # root device hint options include: ['deviceName','hctl','model','vendor','serialNumber','minSizeGigabytes','wwn','rotational']

--- a/ansible-ipi-install/roles/scale-worker/templates/bare-metal-host.yaml.j2
+++ b/ansible-ipi-install/roles/scale-worker/templates/bare-metal-host.yaml.j2
@@ -13,7 +13,19 @@ spec:
   bootMACAddress: "{{ item.prov_mac }}"
 {% if bootmode is defined and bootmode == 'legacy' %}
   bootMode: legacy
-{% endif %}  
+{% endif %}
+{% if multithread is defined or sriov is defined or virtualization is defined %}
+  firmware:
+{% if multithread is defined %}
+    simultaneousMultithreadingEnabled: {{ multithread=true }}
+{% endif %}
+{% if sriov is defined %}
+    sriovEnabled: {{ sriov }}
+{% endif %}
+{% if virtualization is defined %}
+    virtualizationEnabled: {{ virtualization }}
+{% endif %}
+{% endif %}
   userData:
     name: worker-user-data
     namespace: openshift-machine-api

--- a/ansible-ipi-install/roles/scale-worker/templates/bare-metal-host.yaml.j2
+++ b/ansible-ipi-install/roles/scale-worker/templates/bare-metal-host.yaml.j2
@@ -17,7 +17,7 @@ spec:
 {% if multithread is defined or sriov is defined or virtualization is defined %}
   firmware:
 {% if multithread is defined %}
-    simultaneousMultithreadingEnabled: {{ multithread=true }}
+    simultaneousMultithreadingEnabled: {{ multithread }}
 {% endif %}
 {% if sriov is defined %}
     sriovEnabled: {{ sriov }}


### PR DESCRIPTION
# Description

Allows to change some BIOS settings through the BareMetalHost definition.

Some context: [Enable reproducible data plane testing in the scale/alias lab](https://issues.redhat.com/browse/PERFSCALE-2439)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing
Do not merge yet, if everyone agrees on the approach let's take the PR for a ride in the ScaleLab.